### PR TITLE
Added info on SMD diode polarity to english build guide.

### DIFF
--- a/corne-classic/doc/buildguide_en.md
+++ b/corne-classic/doc/buildguide_en.md
@@ -52,6 +52,7 @@ __For Low Profile Keyswitches__
 If you use low profile keyswitches, you have to implement SMD diodes __on the back side__.
 Otherwise, diodes will interfere with top plate.
 
+As with normal diodes, [SMD diodes have polarity](https://learn.sparkfun.com/tutorials/polarity/diode-and-led-polarity). The lines on the SMD diode should be on the same side as the line on the PCB silkscreen.
 
 ### LEDs (Optional)
 


### PR DESCRIPTION
Part of a series of PRs to improve the english build guide by adding some info that I would have wished was there when building the crkbd myself. Split into parts to make it easier to choose which part you want to accept and which to leave our or rewrite if necessary.

This one adds some quick info on how to orient SMD diode polarity correctly.