### PR TITLE
Added info on how to turn LEDs on to the firmware section of the english build guide.

### DIFF
--- a/corne-classic/doc/buildguide_en.md
+++ b/corne-classic/doc/buildguide_en.md
@@ -210,5 +210,12 @@ Detecting USB port, reset your controller now........
 
 Flash the firmware to the other side as well.
 
+### Turning LEDS on
+To turn the LEDs on, you have to edit the `rules.mk` file. If you use the default layout, it can be found here `keyboards/crkbd/keymaps/default/rules.mk`. Add the following line to the top of the file:
+```
+RGBLIGHT_ENABLED = yes
+```
+
+Compile and flash to both sides and all LEDs should turn on and __glow red__ if you have soldered everything correctly. If you run the default firmware and the LEDs turn a differrent color, the data to the LEDs is probably corrupted somewhere along the way. Check the LED before the first one turning a different color using the troubleshooting guide below.
 
 That's it.


### PR DESCRIPTION
Part of a series of PRs to improve the english build guide by adding some info that I would have wished was there when building the crkbd myself. Split into parts to make it easier to choose which part you want to accept and which to leave our or rewrite if necessary.

Simply adds some info in the firmware section on how you go about turning the LEDs on. Also mentions that the LEDs are supposed to turn on red and that if you get a different color, something is probably wrong.