### PR TITLE
[GitHub] Add release gerber files workflow

### DIFF
--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -1,0 +1,21 @@
+name: Release on tag
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+'
+
+jobs:
+  release-gerber-files:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Tag name
+      id: tag_name
+      run: echo ::set-output name=TAG::${GITHUB_REF#refs/tags/}
+    - name: Trigger Release
+      uses: benc-uk/workflow-dispatch@v1
+      with:
+        workflow: Release
+        ref: "${{ github.ref }}"
+        token: ${{ secrets.PERSONAL_TOKEN }}
+        inputs: '{ "ref": "${{ steps.tag_name.outputs.TAG }}" }'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,61 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Ref to release, for example "v2.1" tag'
+        required: true
+
+jobs:
+  release-gerber-files:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.inputs.ref }}
+
+    - name: Export corne-cherry gerber
+      uses: nerdyscout/kicad-exports@master
+      with:
+        cmd: fabrication
+        dir: corne-cherry/gerber
+        board: corne-cherry/pcb/corne-cherry.kicad_pcb
+        schematic: corne-cherry/pcb/corne-cherry.sch
+    - name: Export corne-chocolate gerber
+      uses: nerdyscout/kicad-exports@master
+      with:
+        cmd: fabrication
+        dir: corne-chocolate/gerber
+        board: corne-chocolate/pcb/corne-chocolate.kicad_pcb
+        schematic: corne-chocolate/pcb/corne-chocolate.sch
+    - name: Export corne-classic gerber
+      uses: nerdyscout/kicad-exports@master
+      with:
+        cmd: fabrication
+        dir: corne-classic/gerber
+        board: corne-classic/pcb/corne-classic.kicad_pcb
+        schematic: corne-classic/pcb/corne-classic.sch
+    - name: Export corne-light gerber
+      uses: nerdyscout/kicad-exports@master
+      with:
+        cmd: fabrication
+        dir: corne-light/gerber
+        board: corne-light/pcb/corne-light.kicad_pcb
+        schematic: corne-light/pcb/corne-light.sch
+
+    - name: Zip Gerber files
+      run: |
+          zip -r --junk-paths corne-cherry-gerber.zip corne-cherry/gerber
+          zip -r --junk-paths corne-chocolate-gerber.zip corne-chocolate/gerber
+          zip -r --junk-paths corne-light-gerber.zip corne-light/gerber
+          zip -r --junk-paths corne-classic-gerber.zip corne-classic/gerber
+
+    - name: Release to GiHub
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: ${{ github.event.inputs.ref }}
+        files: "*.zip"
+        draft: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- This provides GitHub actions workflows that creates GitHub releases with gerber files:
  - `Release` workflow is intended to be triggeref manually, and can be used to release older v2.1 version
  - `Release on tag` will automatically trigger the first one when a `vx.y` tag is pushed
- Releases are created as draft so you can edit the description before publishing it.
- You can see Release examples there: [v2.1](https://github.com/carbncl/crkbd/releases/tag/v2.1),  [v2.2](https://github.com/carbncl/crkbd/releases/tag/v2.2).
- You need to add a `PERSONAL_TOKEN` secret for this to work as explained [there](https://github.com/benc-uk/workflow-dispatch#token).
- The gerber files are produced in a docker container with [kicad-exports](https://github.com/nerdyscout/kicad-exports) and looks fine to me, but I've never ordered PCBs from them, some settings changes could be required.