### PR TITLE
Add release gerber files GitHub Actions workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+*'
+
+jobs:
+  release-gerber-files:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Export corne-cherry gerber
+      uses: nerdyscout/kicad-exports@v2.0
+      with:
+        config: .kiplot.yml
+        dir: corne-cherry/gerber
+        board: corne-cherry/pcb/corne-cherry.kicad_pcb
+        schema: corne-cherry/pcb/corne-cherry.sch
+    - name: Export corne-chocolate gerber
+      uses: nerdyscout/kicad-exports@v2.0
+      with:
+        config: .kiplot.yml
+        dir: corne-chocolate/gerber
+        board: corne-chocolate/pcb/corne-chocolate.kicad_pcb
+        schema: corne-chocolate/pcb/corne-chocolate.sch
+    - name: Export corne-classic gerber
+      uses: nerdyscout/kicad-exports@v2.0
+      with:
+        config: .kiplot.yml
+        dir: corne-classic/gerber
+        board: corne-classic/pcb/corne-classic.kicad_pcb
+        schema: corne-classic/pcb/corne-classic.sch
+    - name: Export corne-light gerber
+      uses: nerdyscout/kicad-exports@v2.0
+      with:
+        config: .kiplot.yml
+        dir: corne-light/gerber
+        board: corne-light/pcb/corne-light.kicad_pcb
+        schema: corne-light/pcb/corne-light.sch
+    - name: Export top plate gerber
+      uses: nerdyscout/kicad-exports@v2.0
+      with:
+        config: .kiplot.yml
+        dir: plates/pcb/top/gerber
+        board: plates/pcb/top/corne-top-plate.kicad_pcb
+        schema: plates/pcb/top/corne-top-plate.sch
+    - name: Export bottom plate gerber
+      uses: nerdyscout/kicad-exports@v2.0
+      with:
+        config: .kiplot.yml
+        dir: plates/pcb/bottom/gerber
+        board: plates/pcb/bottom/corne-bottom-plate.kicad_pcb
+        schema: plates/pcb/bottom/corne-bottom-plate.sch
+
+    - name: Zip Gerber files
+      run: |
+          zip -r --junk-paths corne-cherry-gerber.zip corne-cherry/gerber
+          zip -r --junk-paths corne-chocolate-gerber.zip corne-chocolate/gerber
+          zip -r --junk-paths corne-light-gerber.zip corne-light/gerber
+          zip -r --junk-paths corne-classic-gerber.zip corne-classic/gerber
+          zip -r --junk-paths plates-top-gerber.zip plates/pcb/top/gerber
+          zip -r --junk-paths plates-bottom-gerber.zip plates/pcb/bottom/gerber
+
+    - name: Release to GiHub
+      uses: softprops/action-gh-release@v1
+      with:
+        files: "*.zip"
+        draft: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.kiplot.yml
+++ b/.kiplot.yml
@@ -1,0 +1,53 @@
+kiplot:
+  version: 1
+
+preflight:
+  update_xml: false
+  run_drc: false
+  check_zone_fills: true
+  ignore_unconnected: false
+
+# Note: these settings are the ones foostan is using, reference:
+# https://github.com/foostan/crkbd/issues/11#issuecomment-450635794
+outputs:
+  - name: "Gerber files"
+    type: gerber
+    options:
+      # generic layer options
+      exclude_edge_layer: true
+      exclude_pads_from_silkscreen: true
+      use_aux_axis_as_origin: false
+      plot_sheet_reference: false
+      plot_footprint_refs: true
+      plot_footprint_values: true
+      force_plot_invisible_refs_vals: false
+      tent_vias: true
+
+      # gerber options
+      line_width: 0.1
+      subtract_mask_from_silk: false
+      use_protel_extensions: false
+      gerber_precision: 4.6
+      create_gerber_job_file: false
+      use_gerber_x2_attributes: false
+      use_gerber_net_attributes: false
+
+    layers:
+      - layer: F.Cu
+      - layer: B.Cu
+      - layer: F.SilkS
+      - layer: B.SilkS
+      - layer: F.Mask
+      - layer: B.Mask
+      - layer: Edge.Cuts
+
+  - name: "Drill files"
+    type: excellon
+    options:
+      metric_units: true
+      pth_and_npth_single_file: false
+      use_aux_axis_as_origin: false
+      minimal_header: false
+      mirror_y_axis: false
+      map:
+        type: 'gerber'

--- a/plates/pcb/bottom/corne-bottom-plate.sch
+++ b/plates/pcb/bottom/corne-bottom-plate.sch
@@ -1,0 +1,16 @@
+EESchema Schematic File Version 4
+EELAYER 30 0
+EELAYER END
+$Descr A4 11693 8268
+encoding utf-8
+Sheet 1 1
+Title ""
+Date ""
+Rev ""
+Comp ""
+Comment1 ""
+Comment2 ""
+Comment3 ""
+Comment4 ""
+$EndDescr
+$EndSCHEMATC

--- a/plates/pcb/top/corne-top-plate.sch
+++ b/plates/pcb/top/corne-top-plate.sch
@@ -1,0 +1,16 @@
+EESchema Schematic File Version 4
+EELAYER 30 0
+EELAYER END
+$Descr A4 11693 8268
+encoding utf-8
+Sheet 1 1
+Title ""
+Date ""
+Rev ""
+Comp ""
+Comment1 ""
+Comment2 ""
+Comment3 ""
+Comment4 ""
+$EndDescr
+$EndSCHEMATC


### PR DESCRIPTION
This provides GitHub actions workflows that creates GitHub releases with automatically generated gerber files:
- Triggered when a version tag is pushed
- Releases are created as draft so you can edit the description before publishing it
- You can see a release example there: [v2.1+20200808](https://github.com/carbncl/crkbd/releases/tag/v2.1%2B20200808)
- The gerber files are produced in a docker container with [kicad-exports](https://github.com/nerdyscout/kicad-exports) and use a [kiplot](https://github.com/johnbeard/kiplot) configuration file (`.kiplot.yml`) that was written based on [foostan kicad configuration](https://github.com/foostan/crkbd/issues/11#issuecomment-450635794) and should be fine for a manufacturer such as JLCPCB
- Sadly, empty `.sch` files had to be added for plates because of a limitation of kicad-export