### PR TITLE
Cleanup Markdown, mostly syntax and line-length

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # Corne keyboard
 
-The Corne keyboard is a split keyboard with 3x6 column staggered keys and 3 thumb keys,
-based on [Helix](https://github.com/MakotoKurauchi/helix).
+The Corne keyboard is a split keyboard with 3x6 column staggered keys
+and 3 thumb keys, based on [Helix](https://github.com/MakotoKurauchi/helix).
 Crkbd stands for Corne Keyboard.
 
 ## Lineup
 
 - corne-classic([JP](corne-classic/doc/buildguide_jp.md)/[EN](corne-classic/doc/buildguide_en.md)):
-    Corne for Cherry MX switches
+  Corne for Cherry MX switches
 - corne-cherry([JP](corne-cherry/doc/buildguide_jp.md)) ([tilting, JP](corne-cherry/doc/v2/buildguide_tilting_tenting_plate_jp.md)):
-    Hotswappable Corne for Cherry MX switches by kailh PCB sockets.
+  Hotswappable Corne for Cherry MX switches by kailh PCB sockets.
 - corne-chocolate([JP](corne-chocolate/doc/buildguide_jp.md)/[EN](corne-chocolate/doc/buildguide_en.md)):
-    Hotswappable Corne for Chocolate switches using Kailh PCB hot-swap sockets.
+  Hotswappable Corne for Chocolate switches using Kailh PCB hot-swap sockets.
 - corne-light([JP](corne-light/doc/buildguide_jp.md)):
-    Light-weight Corne (Easy build with a simple PCB).
+  Light-weight Corne (Easy build with a simple PCB).
 
 ## Photos
 

--- a/corne-cherry/doc/v2/buildguide_jp.md
+++ b/corne-cherry/doc/v2/buildguide_jp.md
@@ -4,8 +4,10 @@
 [Corne Cherry v3 はこちら](https://github.com/foostan/crkbd/blob/master/corne-cherry/doc/v3/buildguide_jp.md)。
 
 ## 部品
+
 ### 必須
-| 名前 | 数 | 備考 | 
+
+| 名前 | 数 | 備考 |
 |:-|:-|:-|
 | PCB | 2枚 | |
 | トッププレート | 2枚 | |
@@ -29,6 +31,7 @@
 | Micro USBケーブル | 1本 | |
 
 ### オプション
+
 | 名前 | 数 | 備考 |
 |:-|:-|:-|
 | SK6812MINI | 54個 | 上向き実装 42個、下向き実装 12個 |
@@ -36,8 +39,9 @@
 ![01](https://user-images.githubusercontent.com/736191/54487431-789a6c00-48d9-11e9-9390-a8510b19ba34.jpg)
 
 ## 事前準備
+
 ファームウェアを自分でビルドする場合は環境を整備するのに時間がかかるのではじめに取り掛かっておくことをおすすめします。\
-詳しくは https://github.com/foostan/crkbd/blob/master/doc/firmware_jp.md を参照してください。
+詳しくは <https://github.com/foostan/crkbd/blob/master/doc/firmware_jp.md> を参照してください。
 
 ## 実装
 
@@ -56,7 +60,7 @@ PCBはリバーシブルになっているので、最初にどちらを左用/�
 
 ![03](https://user-images.githubusercontent.com/736191/54487433-789a6c00-48d9-11e9-991b-92264a793ec9.jpg)
 
-ダイオードの向きは次のとおりです。チップ部品の「|||」印が、ダイオードマーク「|◁」の「|」の方に向けるように取り付けます。 
+ダイオードの向きは次のとおりです。チップ部品の「|||」印が、ダイオードマーク「|◁」の「|」の方に向けるように取り付けます。
 
 ![04](https://user-images.githubusercontent.com/736191/54487434-79330280-48d9-11e9-82be-a9d98803a417.jpg)
 
@@ -89,6 +93,7 @@ PCBはリバーシブルになっているので、最初にどちらを左用/�
 ![09](https://user-images.githubusercontent.com/736191/54487439-79cb9900-48d9-11e9-9a57-80697fa8b484.jpg)
 
 ### OLEDモジュールのためのジャンパとピンソケット
+
 OLEDモジュールを利用する場合は下記のようにジャンパします。
 なお**表面のみジャンパしてください**。
 
@@ -100,6 +105,7 @@ OLEDモジュールを利用する場合は下記のようにジャンパしま�
 その場合は、はんだを多めに使うか、別途フラックスを塗るとうまくジャンパができます。
 
 ### ProMicro
+
 ピンヘッダを白い枠に当てはめるようにはんだづけし、そこにProMicroの裏面を上にしてはんだづけします。
 
 ![11](https://user-images.githubusercontent.com/736191/54487441-79cb9900-48d9-11e9-9317-e77c4c408a4f.jpg)
@@ -108,6 +114,7 @@ OLEDモジュールを利用する場合は下記のようにジャンパしま�
 なおスプリングピンヘッダを利用する場合は [Helix のビルドガイド](https://github.com/MakotoKurauchi/helix/blob/master/Doc/buildguide_jp.md#pro-micro)を参考にしてください。
 
 ### OLEDモジュール
+
 OLED用のピンソケットにピンヘッダを先に差し込み、その後からピンヘッダとOLEDモジュールをはんだづけします。
 このときOLEDモジュールが浮きやすいので指で押さえつけながら浮かないように気をつけます。
 
@@ -115,6 +122,7 @@ OLED用のピンソケットにピンヘッダを先に差し込み、その後�
 ![14](https://user-images.githubusercontent.com/736191/54487445-7a642f80-48d9-11e9-9bb0-f753a5e4720b.jpg)
 
 ### 動作確認
+
 ProMicroとOLEDモジュールを付けた段階で動作確認をすることをおすすめします(一番最後にやると問題の切り分けが難しくなる)。
 
 動作確認をする場合は先に下記の「ファームウェア」の章を参考にしてcrkbd用のファームウェアをProMicroに入れてください（必ず両側に入れてください）。
@@ -124,6 +132,7 @@ ProMicroとOLEDモジュールを付けた段階で動作確認をすること�
 ![15](https://user-images.githubusercontent.com/736191/54487446-7a642f80-48d9-11e9-8bd2-2b413e3e080a.jpg)
 
 ### Kailh PCBソケット
+
 裏面の両側のパッドにはんだを盛ります。後から追加するのが難しいので予め多めに盛ってください。
 
 ![16](https://user-images.githubusercontent.com/736191/54487447-7afcc600-48d9-11e9-91cb-edd541365180.jpg)
@@ -150,10 +159,12 @@ ProMicroとOLEDモジュールを付けた段階で動作確認をすること�
 ![20](https://user-images.githubusercontent.com/736191/54487451-7afcc600-48d9-11e9-8c90-2f2919bf9483.jpg)
 
 ## ファームウェア
+
 下記を参照しファームウェアをProMicroに書き込みます。\
-https://github.com/foostan/crkbd/blob/master/doc/firmware_jp.md
+<https://github.com/foostan/crkbd/blob/master/doc/firmware_jp.md>
 
 ## LED（オプション）
+
 SK6812MINIを取り付けていきます。
 
 SK6812MINIは非常に熱に弱く、簡単に壊れます。

--- a/corne-cherry/doc/v2/buildguide_tilting_tenting_plate_jp.md
+++ b/corne-cherry/doc/v2/buildguide_tilting_tenting_plate_jp.md
@@ -1,7 +1,8 @@
-# Build Guide Tilting/Tenting plate 
+# Build Guide Tilting/Tenting plate
 
 ## 部品
-| 名前 | 数 | 備考 | 
+
+| 名前 | 数 | 備考 |
 |:-|:-|:-|
 | 完成済み Corne Cherry | 1セット | Corne Chocolate / 3mmのトッププレート は非対応 |
 | ミドルプレート 3mm | 2枚 | |

--- a/corne-cherry/doc/v3/buildguide_jp.md
+++ b/corne-cherry/doc/v3/buildguide_jp.md
@@ -3,10 +3,11 @@
 こちらは Corne Cherry v3 のビルドガイドになります。
 [Corne Cherry v2 はこちら](https://github.com/foostan/crkbd/blob/master/corne-cherry/doc/v2/buildguide_jp.md)。
 
-
 ## 部品
+
 ### 必須
-| 名前 | 数 | 備考 | 
+
+| 名前 | 数 | 備考 |
 |:-|:-|:-|
 | PCB | 1セット | |
 | トッププレート | 2枚 | |
@@ -27,6 +28,7 @@
 | Micro USBケーブル | 1本 | |
 
 ### オプション
+
 | 名前 | 数 | 備考 |
 |:-|:-|:-|
 | OLEDモジュール | 2枚 | |
@@ -36,8 +38,9 @@
 | WS2812B | 12個 | Undergrow 用 LEDs |
 
 ## 事前準備
+
 ファームウェアを自分でビルドする場合は環境を整備するのに時間がかかるのではじめに取り掛かっておくことをおすすめします。\
-詳しくは https://github.com/foostan/crkbd/blob/master/doc/firmware_jp.md を参照してください。
+詳しくは <https://github.com/foostan/crkbd/blob/master/doc/firmware_jp.md> を参照してください。
 
 ## 確認
 
@@ -56,6 +59,7 @@ PCBは製造の都合上フレームが付いた状態となっています。
 ![confirm_remove_frame](assets/confirm_remove_frame.jpg)
 
 ## 組み立て
+
 ### ダイオード
 
 SMD部品のダイオードのはんだづけを行います。
@@ -134,7 +138,6 @@ SK6812MINI に比べて壊れにくいですが、はんだごての熱を直接
 
 ![build_led_backlight](assets/build_led_backlight.jpg)
 
-
 左右合わせて計42個はんだづけして SK6812MINI-E は完了です。
 
 ![build_led_back_overview](assets/build_led_back_overview.jpg)
@@ -148,6 +151,7 @@ SK6812MINI に比べて壊れにくいですが、はんだごての熱を直接
 ずれやすい部品なので、手で部品を抑えながらはんだづけするか、マスキングテープ等で固定してからはんだづけするときれいに付きます。
 
 ### ProMicro
+
 ProMicroを下記のような向きではんだ付けします
 
 ![build_promicro](assets/build_promicro.jpg)
@@ -158,16 +162,19 @@ ProMicroを下記のような向きではんだ付けします
 ![build_promicro_conthrough](assets/build_promicro_conthrough.jpg)
 
 ### OLEDモジュール
+
 OLED用のピンソケットにピンヘッダを先に差し込み、その後からピンヘッダとOLEDモジュールをはんだづけします。
 このときOLEDモジュールが浮きやすいので指で押さえつけながら浮かないように気をつけます。
 
 ![build_oled](assets/build_oled.jpg)
 
 ## ファームウェア
+
 下記を参照しファームウェアをProMicroに書き込みます。\
-https://github.com/foostan/crkbd/blob/master/doc/firmware_jp.md
+<https://github.com/foostan/crkbd/blob/master/doc/firmware_jp.md>
 
 ### 動作確認
+
 ProMicroとOLEDモジュールを付けた段階で動作確認をすることをおすすめします。
 一番最後にやると問題の切り分けが難しくなります。
 

--- a/corne-chocolate/doc/buildguide_en.md
+++ b/corne-chocolate/doc/buildguide_en.md
@@ -1,7 +1,8 @@
 # Build Guide
 
 This is the build guide for Corne Chocolate.
-[Click here for Corne Cherry](https://github.com/foostan/crkbd/blob/master/corne-cherry/doc/buildguide_en.md).
+[Click here for Corne Cherry](
+https://github.com/foostan/crkbd/blob/master/corne-cherry/doc/buildguide_en.md).
 
 ## Parts
 
@@ -38,8 +39,11 @@ This is the build guide for Corne Chocolate.
 
 ## Preparation
 
-If you build the firmware yourself, it will take some time to set up the environment, so it's best to start at the beginning. \
-For more information, please see https://github.com/foostan/crkbd/blob/master/doc/firmware_en.md.
+If you build the firmware yourself,
+it will take some time to set up the environment,
+so it's best to start at the beginning. \
+For more information,
+please see <https://github.com/foostan/crkbd/blob/master/doc/firmware_en.md>.
 
 ## Building
 
@@ -59,13 +63,15 @@ Mounting on the front will interfere with the top plate.
 Since the diodes are very small,
 it is easier to work with tweezers and inverted tweezers.
 Since the **mounting orientation of the diode is crucial**,
-it is possible to proceed smoothly if you arrange the columns and rows to be mounted in advance,
+it is possible to proceed smoothly
+if you arrange the columns and rows to be mounted in advance,
 as shown in the following photo.
 
 ![](https://user-images.githubusercontent.com/736191/52534466-1b187a00-2d85-11e9-8ce3-bb13067a1b29.png)
 
 The orientation of the diode is as follows.
-Attach the chip component so that the "|||" mark on the diode is facing the "|" of the diode mark "| ◁" on the PCB (image from Corne Cherry).
+Attach the chip component so that the "|||" mark on the diode is facing the "|"
+of the diode mark "|◁" on the PCB (image from Corne Cherry).
 
 ![](https://user-images.githubusercontent.com/736191/54487560-cb285800-48da-11e9-9e1e-aafaacf5723c.jpg)
 
@@ -76,7 +82,8 @@ First put solder only on the right side of the pad.
 
 Next, solder one of the diodes by melting the solder you already put on the board.
 At this time,
-it is recommended that you use inverted tweezers so that you can hold the SMD part firmly without applying force,
+it is recommended that you use inverted tweezers
+so that you can hold the SMD part firmly without applying force,
 and concentrate on alignment and soldering instead.
 Also, if the soldering iron is too hot or the solder is touched too long,
 the flux contained in the solder may evaporate and a solder pile may be formed,
@@ -127,7 +134,8 @@ If so, you cna fix the jumper by applying more solder or separate flux.
 
 ![](https://user-images.githubusercontent.com/736191/52534637-99761b80-2d87-11e9-958a-c6ca836a7936.png)
 
-Solder the pin headers to the white frame and solder the Pro Micro with back side up.
+Solder the pin headers to the white frame
+and solder the Pro Micro with back side up.
 
 ![](https://user-images.githubusercontent.com/736191/52534641-a266ed00-2d87-11e9-8dcb-832b90556ac2.png)
 ![](https://user-images.githubusercontent.com/736191/52534643-aa269180-2d87-11e9-9c05-67924d235968.png)
@@ -142,7 +150,8 @@ please refer to the [Helix Build Guide](https://github.com/MakotoKurauchi/helix/
 Insert the pin header into the OLED pin socket first,
 then solder the pin header and the OLED module.
 At this time,
-make sure that he OLED module sits tightly on the socket while holding it down with your finger,
+make sure that he OLED module sits tightly on the socket
+while holding it down with your finger,
 because it tends to stick out easily.
 
 ![](https://user-images.githubusercontent.com/736191/52534720-5e281c80-2d88-11e9-9b76-164d9b63692f.png)
@@ -150,16 +159,21 @@ because it tends to stick out easily.
 
 ### Operation check
 
-We recommend that you check the operation at the stage where the Pro Micro and OLED modules are attached (it is difficult to isolate the problem at the end).
+We recommend that you check the operation at the stage
+where the Pro Micro and OLED modules are attached
+(it is difficult to isolate the problem at the end).
 
 Before checking the correct operation,
-flash the crkbd firmware to the Pro Micro by referring to the [Firmware](#firmware) section below
+flash the crkbd firmware to the Pro Micro
+by referring to the [Firmware](#firmware) section below
 (be sure to insert it on both sides).
 
-Operation confirmation is performed by connecting the left hand side to a PC with Micro USB
+Operation confirmation is performed
+by connecting the left hand side to a PC with Micro USB
 and connecting the left hand side and the right hand side with a TRS cable.
 Since there may be a defect such as a jack,
-make sure to connect the left and right instead of one by one before checking the operation.
+make sure to connect the left and right
+instead of one by one before checking the operation.
 If you have done this correctly,
 short-circuit the pad to attach the PCB socket with tweezers,
 and the key pressed on the OLED module will be displayed.
@@ -176,12 +190,14 @@ so if you are worried about mounting it,
 we recommend that you skip this chapter and complete it first.
 
 SK6812MINI is very heat sensitive and breaks easily.
-We recommend using a soldering iron with a temperature control function and operating at a temperature of about 220°C to 270°C.
+We recommend using a soldering iron with a temperature control function
+and operating at a temperature of about 220°C to 270°C.
 Even if the temperature is set that low,
 the LED will be damaged if the iron is left on it for a long time,
 so try to solder as quickly as possible.
 Solder four LEDs at a time,
-but we recommend soldering two at a time instead of four at a time to prevent the LED temperature from rising,
+but we recommend soldering two at a time instead of four at a time
+to prevent the LED temperature from rising,
 as this will make it less likely to overheat.
 
 First, check the mounting position.
@@ -194,13 +210,15 @@ Below is the location to attach the LED (image from Corne Cherry).
 ![](https://user-images.githubusercontent.com/736191/46822569-cc52d780-cdc6-11e8-9602-f6265a2c876d.png)
 
 For LEDs 1 to 6,
-solder the part so that the black part circled below is on the bottom and the silk mark indicated by the arrow is on the top.
+solder the part so that the black part circled below is on the bottom
+and the silk mark indicated by the arrow is on the top.
 Note that the direction changes between 1 - 3 and 4 - 5.
 
 ![](https://user-images.githubusercontent.com/736191/46822428-6d8d5e00-cdc6-11e8-8858-06e8dbdb8ee8.png)
 
 For 7 - 27,
-perform soldering so that the largest pad surrounded by a circle and the silk mark indicated by an arrow are adjacent to each other,
+perform soldering so that the largest pad surrounded by a circle
+and the silk mark indicated by an arrow are adjacent to each other,
 as shown below.
 
 ![](https://user-images.githubusercontent.com/736191/46822434-6ebe8b00-cdc6-11e8-9686-69ac88bb4389.png)

--- a/corne-chocolate/doc/buildguide_en.md
+++ b/corne-chocolate/doc/buildguide_en.md
@@ -141,7 +141,7 @@ and solder the Pro Micro with back side up.
 ![](https://user-images.githubusercontent.com/736191/52534643-aa269180-2d87-11e9-9c05-67924d235968.png)
 
 When using the spring pin header,
-please refer to the [Helix Build Guide](https://github.com/MakotoKurauchi/helix/blob/master/Doc/buildguide_jp.md#pro-micro).
+please refer to the [Helix Build Guide](https://github.com/MakotoKurauchi/helix/blob/master/Doc/buildguide_en.md#pro-micro).
 
 ### OLED module
 

--- a/corne-chocolate/doc/buildguide_en.md
+++ b/corne-chocolate/doc/buildguide_en.md
@@ -7,7 +7,7 @@ This is the build guide for Corne Chocolate.
 
 ### Required
 
-| Name | Number | Remarks | 
+| Name | Number | Remarks |
 |:-|:-|:-|
 | PCB | 2 pieces | |
 | Top plate | 2 pieces | |
@@ -37,6 +37,7 @@ This is the build guide for Corne Chocolate.
 | SK6812MINI | 54 | 42 for backlight, 12 for under-glow |
 
 ## Preparation
+
 If you build the firmware yourself, it will take some time to set up the environment, so it's best to start at the beginning. \
 For more information, please see https://github.com/foostan/crkbd/blob/master/doc/firmware_en.md.
 
@@ -252,8 +253,9 @@ because it looks better.
 ![](https://user-images.githubusercontent.com/736191/52534914-00e19a80-2d8b-11e9-8005-7e0b157e09e4.png)
 
 ## Firmware
+
 See below to flash the firmware to the ProMicro. \
-https://github.com/foostan/crkbd/blob/master/doc/firmware_en.md
+<https://github.com/foostan/crkbd/blob/master/doc/firmware_en.md>
 
 This is the end.
 

--- a/corne-chocolate/doc/buildguide_jp.md
+++ b/corne-chocolate/doc/buildguide_jp.md
@@ -4,8 +4,10 @@
 [Corne Cherry はこちら](https://github.com/foostan/crkbd/blob/master/corne-cherry/doc/buildguide_jp.md)。
 
 ## 部品
+
 ### 必須
-| 名前 | 数 | 備考 | 
+
+| 名前 | 数 | 備考 |
 |:-|:-|:-|
 | PCB | 2枚 | |
 | トッププレート | 2枚 | |
@@ -29,13 +31,15 @@
 | Micro USBケーブル | 1本 | |
 
 ### オプション
+
 | 名前 | 数 | 備考 |
 |:-|:-|:-|
 | SK6812MINI | 54個 | 上向き実装 42個、下向き実装 12個 |
 
 ## 事前準備
+
 ファームウェアを自分でビルドする場合は環境を整備するのに時間がかかるのではじめに取り掛かっておくことをおすすめします。\
-詳しくは https://github.com/foostan/crkbd/blob/master/doc/firmware_jp.md を参照してください。
+詳しくは <https://github.com/foostan/crkbd/blob/master/doc/firmware_jp.md> を参照してください。
 
 ## 実装
 
@@ -44,7 +48,6 @@ PCBはリバーシブルになっているので、最初にどちらを左用/�
 ![01](https://user-images.githubusercontent.com/736191/52534345-dcce8b00-2d83-11e9-9b6a-b1f9f4b75519.png)
 
 ### ダイオード
-
 
 チップ部品のダイオードのはんだづけを行います。
 Corne Cherryではどちらの面に取り付けるかは自由でしたが、Corne Chocolateでは**必ず裏面に取り付けてください**。
@@ -55,7 +58,7 @@ Corne Cherryではどちらの面に取り付けるかは自由でしたが、Co
 
 ![02](https://user-images.githubusercontent.com/736191/52534466-1b187a00-2d85-11e9-8ce3-bb13067a1b29.png)
 
-ダイオードの向きは次のとおりです。チップ部品の「|||」印が、ダイオードマーク「|◁」の「|」の方に向けるように取り付けます(画像はCorne Cherryから転記)。 
+ダイオードの向きは次のとおりです。チップ部品の「|||」印が、ダイオードマーク「|◁」の「|」の方に向けるように取り付けます(画像はCorne Cherryから転記)。
 
 ![03](https://user-images.githubusercontent.com/736191/54487560-cb285800-48da-11e9-9e1e-aafaacf5723c.jpg)
 
@@ -88,6 +91,7 @@ Corne Cherryではどちらの面に取り付けるかは自由でしたが、Co
 ![09](https://user-images.githubusercontent.com/736191/52534621-40a68300-2d87-11e9-9749-14459d2b1eac.png)
 
 ### OLEDモジュールのためのジャンパ
+
 OLEDモジュールを利用する場合は下記のようにジャンパします。
 なお**表面のみジャンパしてください**。
 
@@ -118,6 +122,7 @@ OLED用のピンソケットにピンヘッダを先に差し込み、その後�
 ![16](https://user-images.githubusercontent.com/736191/52534722-67b18480-2d88-11e9-94d0-e3c899bcc020.png)
 
 ### 動作確認
+
 ProMicroとOLEDモジュールを付けた段階で動作確認をすることをおすすめします(一番最後にやると問題の切り分けが難しくなる)。
 
 動作確認をする場合は先に下記の「ファームウェア」の章を参考にしてcrkbd用のファームウェアをProMicroに入れてください（必ず両側に入れてください）。
@@ -162,6 +167,7 @@ LEDは４つずつはんだづけを行いますが、一度に４つ行わず�
 ![25](https://user-images.githubusercontent.com/736191/52534811-85331e00-2d89-11e9-9752-c40ffab23419.png)
 
 ### Kailh PCBソケット
+
 ![26](https://user-images.githubusercontent.com/736191/52534832-be6b8e00-2d89-11e9-82e6-be53dd82bf59.png)
 
 裏面の両側のパッドにはんだを盛ります。後から追加するのが難しいので予め多めに盛ってください。
@@ -191,12 +197,10 @@ LEDは４つずつはんだづけを行いますが、一度に４つ行わず�
 ![33](https://user-images.githubusercontent.com/736191/52534914-00e19a80-2d8b-11e9-8005-7e0b157e09e4.png)
 
 ## ファームウェア
+
 下記を参照しファームウェアをProMicroに書き込みます。\
-https://github.com/foostan/crkbd/blob/master/doc/firmware_jp.md
+<https://github.com/foostan/crkbd/blob/master/doc/firmware_jp.md>
 
 以上で完成です。
 
 ![34](https://user-images.githubusercontent.com/736191/52534969-be6c8d80-2d8b-11e9-82ac-a2cd09ab96d1.png)
-
-
-

--- a/corne-classic/doc/buildguide_en.md
+++ b/corne-classic/doc/buildguide_en.md
@@ -34,8 +34,11 @@
 
 ## Preparation
 
-If you build the firmware yourself, it will take some time to set up the environment, so it's best to start at the beginning. \
-For more information, please see https://github.com/foostan/crkbd/blob/master/doc/firmware_en.md.
+If you build the firmware yourself,
+it will take some time to set up the environment,
+so it's best to start at the beginning. \
+For more information,
+please see <https://github.com/foostan/crkbd/blob/master/doc/firmware_en.md>.
 
 ## Soldering
 
@@ -44,12 +47,16 @@ PCB is reversible; use one for the left hand side and the other for the right.
 ### Diodes
 
 #### For non Low Profile keyswitches
-Solder diodes as indicated in the picture. You can place it on either side, but front side is recommended if you implement under-glow LED. You can use SMD diodes too.
+
+Solder diodes as indicated in the picture.
+You can place it on either side,
+but front side is recommended if you implement under-glow LED.
+You can use SMD diodes too.
 
 ![image](https://user-images.githubusercontent.com/736191/40736513-306a0976-6479-11e8-8f98-a88073919a71.png)
 
-
-Diode has polarity; make sure to match the polarity with PCB silkscreen.
+Diode has polarity;
+make sure to match the polarity with PCB silkscreen.
 
 <- Before | After ->
 
@@ -57,35 +64,56 @@ Diode has polarity; make sure to match the polarity with PCB silkscreen.
 
 #### For Low Profile Keyswitches
 
-If you use low profile keyswitches, you have to implement SMD diodes __on the back side__.
+If you use low profile keyswitches,
+you have to implement SMD diodes __on the back side__.
 Otherwise, diodes will interfere with top plate.
 
-As with normal diodes, [SMD diodes have polarity](https://learn.sparkfun.com/tutorials/polarity/diode-and-led-polarity). The lines on the SMD diode should be on the same side as the line on the PCB silkscreen.
+As with normal diodes,
+[SMD diodes have polarity](https://learn.sparkfun.com/tutorials/polarity/diode-and-led-polarity).
+The lines on the SMD diode should be on the same side as the line on the PCB silkscreen.
 
 ### LEDs (Optional)
 
-Implement LEDs under keyswitches (No. 7 through 27) upward facing, and others (No. 1 through 6) on the back side(under-glow), as indicated in the picture.
+Implement LEDs under keyswitches (No. 7 through 27) upward facing,
+and others (No. 1 through 6) on the back side(under-glow),
+as indicated in the picture.
 
 ![image](https://user-images.githubusercontent.com/736191/40731604-62cee61e-646c-11e8-865f-829a48fa6be0.png)
 
 For No.7 to 27 LEDs, __Install LEDs from the back side__ as shown below.
-Note the '**o**' silkscreen marking and use them as a guide to implement LEDs in the direction. On some versions  of the PCB (e.g. Corne-cherry v2), the '**o**' silkscreen marking has been replaced by a white square around one of the pads, but the principle is still the same.
+Note the '**o**' silkscreen marking
+and use them as a guide to implement LEDs in the direction.
+On some versions  of the PCB (e.g. Corne-cherry v2),
+the '**o**' silkscreen marking has been replaced by a white square
+around one of the pads,
+but the principle is still the same.
 
 ![image](https://user-images.githubusercontent.com/736191/40731605-62f840a4-646c-11e8-99d5-b3bdff709e9d.png)
 
-The LED has one pad that is shaped like a square. That square should connect to the pad that has the '**o**' silkscreen marking:
+The LED has one pad that is shaped like a square.
+That square should connect to the pad that has the '**o**' silkscreen marking:
 
 ![image](https://user-images.githubusercontent.com/5037505/65895453-ca08d500-e3ab-11e9-81f3-1e03aa1fe547.jpg)
 
-There are many different techniques on how to solder the LEDs, but [this video](https://twitter.com/foostan/status/1005656803818889216) might give you an idea on how to do it.
+There are many different techniques on how to solder the LEDs,
+but [this video](https://twitter.com/foostan/status/1005656803818889216)
+might give you an idea on how to do it.
 
-For No. 1 to 6 LEDs, solder the pattern on the side of the device (highlighted in pink on the picture) and the PCB pattern(blue on the picture). Apply flux and take small amount of solder with a soldering iron and press it on the edge of the patterns.
+For No. 1 to 6 LEDs, solder the pattern on the side of the device
+(highlighted in pink on the picture) and the PCB pattern (blue on the picture).
+Apply flux and take small amount of solder with a soldering iron
+and press it on the edge of the patterns.
 
 ![image](https://user-images.githubusercontent.com/736191/40733058-c0558402-646f-11e8-9718-e579fab4aaf5.png)
 
-LEDs are connected in the order of the number on the picture above. If it turns on only halfway, it is likely that first LED that doesn't turn on or the last LED that turns on is not implemented correctly.
+LEDs are connected in the order of the number on the picture above.
+If it turns on only halfway,
+it is likely that first LED that doesn't turn on
+or the last LED that turns on is not implemented correctly.
 
-__Note__ that the default Crkbd firmware has __LEDs turned off__, so you'll have to turn them on before you can test (see the firmware section for instructions how).
+__Note__ that the default Crkbd firmware has __LEDs turned off__,
+so you'll have to turn them on before you can test
+(see the firmware section for instructions how).
 
 ### Jumpers for OLED modules (optional)
 
@@ -103,17 +131,26 @@ For OLEDs, also implement pin sockets.
 
 ### ProMicro
 
-Before you start, flash the Crkbd firmware to the ProMicros to make sure they are alright.
+Before you start,
+flash the Crkbd firmware to the ProMicros to make sure they are alright.
 
-The ProMicro is then installed __in the set of holes that has a white frame on the frontside of the PCB__. Make sure you solder it in the right set of holes, as desoldering the ProMicro is hard. Implement pin headers in the white frame, then install ProMicro with its __backside up__.
+The ProMicro is then installed
+__in the set of holes that has a white frame on the frontside of the PCB__.
+Make sure you solder it in the right set of holes,
+as desoldering the ProMicro is hard.
+Implement pin headers in the white frame,
+then install ProMicro with its __backside up__.
 
 ![image](https://user-images.githubusercontent.com/736191/40737973-3f404de4-647d-11e8-84fe-37f3a34e4c53.png)
 
-The picture is the right hand side, but it's the same for the left hand side - pins into the through holes in the white frame as seen from the frontside, placing the ProMicro with its backside up.
+The picture is the right hand side, but it's the same for the left hand side -
+pins into the through holes in the white frame as seen from the frontside,
+placing the ProMicro with its backside up.
 
 ### OLED Module
 
-Implement pin header onto the OLED modules, then insert them into the pin sockets.
+Implement pin header onto the OLED modules,
+then insert them into the pin sockets.
 
 ![image](https://user-images.githubusercontent.com/736191/40888530-7420d1aa-6793-11e8-8813-9681c1411a21.png)
 
@@ -122,7 +159,9 @@ Most common pin header/socket and 11mm spacers are used in the picture.
 
 ### Use socket to Mount ProMicro
 
-With using sockets for mounting ProMicro, you can replace it easily when it breaks. Two methods are introduced here.
+With using sockets for mounting ProMicro,
+you can replace it easily when it breaks.
+Two methods are introduced here.
 
 #### Using Spring Loaded Header
 
@@ -132,7 +171,8 @@ ProMicro kit with spring loaded headers is available at Yusha-Kobo
 
 <https://yushakobo.jp/shop/promicro-spring-pinheader/>
 
-Using OLEDs available at Yusha-Kobo which come with low profile header, together with and 9mm spacers, you can build them think and gap-less.
+Using OLEDs available at Yusha-Kobo which come with low profile header,
+together with and 9mm spacers, you can build them think and gap-less.
 
 ![img_4141](https://user-images.githubusercontent.com/736191/41304818-2b65511e-6eac-11e8-9357-999ff14080ed.png)
 
@@ -150,7 +190,8 @@ Using male 12x1 pin headers, fixate ProMicro onto the pin sockets.
 
 ![img_4131](https://user-images.githubusercontent.com/736191/41305247-4fbd3e5e-6ead-11e8-8c4d-5feea5a026d3.png)
 
-Remove plastic pin holders, solder the pins to ProMicro, and then cut extra pins.
+Remove plastic pin holders, solder the pins to ProMicro,
+and then cut extra pins.
 
 ![img_4132](https://user-images.githubusercontent.com/736191/41305251-5198439a-6ead-11e8-80f4-bd1769915bc9.png)
 
@@ -160,22 +201,42 @@ Spring loaded headers can make the height lower.
 
 ![img_4134](https://user-images.githubusercontent.com/736191/41305254-53bc4522-6ead-11e8-83ed-c4c7c2787828.png)
 
-Comparing pin-headers in the picture. Headers come with OLED available at Yusha-Kobo are lower.
+Comparing pin-headers in the picture.
+Headers come with OLED available at Yusha-Kobo are lower.
 
 ![img_4137](https://user-images.githubusercontent.com/736191/41305263-57e53dac-6ead-11e8-9b5d-5667bca5599e.png)
 
 ### Testing
-It is recommended to test the ProMicro and OLED modules before installing keyswitches because rework would be difficult after that.
 
-First, build QMK Firmware for built for Crkbd and install on ProMicro (if you haven't already done so).
+It is recommended to test the ProMicro and OLED modules
+before installing keyswitches,
+because rework would be difficult after that.
+
+First, build QMK Firmware for built for Crkbd
+and install on ProMicro (if you haven't already done so).
 
 ![image](https://user-images.githubusercontent.com/736191/40888832-0d793c3a-6798-11e8-93b4-55ec7e180748.png)
 
-Using the default keymap, OLED will show information on the keyswitches being pressed. Check the connections by short-circuiting keyswitch soldering pads with tweezers or a bit of soldering wire. Check all of them.
+Using the default keymap,
+OLED will show information on the keyswitches being pressed.
+Check the connections by short-circuiting keyswitch soldering pads
+with tweezers or a bit of soldering wire.
+Check all of them.
 
-If you have OLED displays, you can verify that all keys are responding by looking at the log information showed there. It will say which row and column was pressed, e.g. `1x5` or `0x2`. Using the tweezers or wire, connect each buttons soldering pads and make sure the display changes. If something isn't working, take note of the which row x column it is that isn't working, as it can help when troubleshooting.
+If you have OLED displays,
+you can verify that all keys are responding
+by looking at the log information showed there.
+It will say which row and column was pressed,
+e.g. `1x5` or `0x2`. Using the tweezers or wire,
+connect each buttons soldering pads and make sure the display changes.
+If something isn't working,
+take note of the which row x column it is that isn't working,
+as it can help when troubleshooting.
 
-If you have mounted LEDs, also make sure all of them are turned on. As note before, the default firmware has LEDs __turned off__, so you have to turn them on in the firmware before you test.
+If you have mounted LEDs,
+also make sure all of them are turned on.
+As note before, the default firmware has LEDs __turned off__,
+so you have to turn them on in the firmware before you test.
 
 ![image](https://user-images.githubusercontent.com/736191/40888868-73028d36-6798-11e8-8246-0c9ca32711d6.png)
 
@@ -206,13 +267,21 @@ See below to flash the firmware to the ProMicro. \
 
 ### Turning LEDS on
 
-To turn the LEDs on, you have to edit the `rules.mk` file. If you use the default layout, it can be found here `keyboards/crkbd/keymaps/default/rules.mk`. Add the following line to the top of the file:
+To turn the LEDs on, you have to edit the `rules.mk` file.
+If you use the default layout,
+it can be found here `keyboards/crkbd/keymaps/default/rules.mk`.
+Add the following line to the top of the file:
 
 ```
 RGBLIGHT_ENABLE = yes
 ```
 
-Compile and flash to both sides and all LEDs should turn on and __glow red__ if you have soldered everything correctly. If you run the default firmware and the LEDs turn a differrent color, the data to the LEDs is probably corrupted somewhere along the way. Check the LED before the first one turning a different color using the troubleshooting guide below.
+Compile and flash to both sides and all LEDs should turn on
+and __glow red__ if you have soldered everything correctly.
+If you run the default firmware and the LEDs turn a differrent color,
+the data to the LEDs is probably corrupted somewhere along the way.
+Check the LED before the first one
+turning a different color using the troubleshooting guide below.
 
 ## Troubleshooting
 
@@ -220,27 +289,56 @@ Here are some tips and tricks on how to troubleshot a board that is not working.
 
 ### No LEDs turn on
 
-There are a number of things that might be wrong. First of all, make sure you have __turned on LED lighting in the firmware__. If that is the case, then chances are there might be a problem with the first LED. Try the suggestions in the next section.
+There are a number of things that might be wrong.
+First of all, make sure you have __turned on LED lighting in the firmware__.
+If that is the case, then chances are there might be a problem with the first LED.
+Try the suggestions in the next section.
 
 ### Some LEDs not turning on
 
-If some LEDs aren't turning on, check the first LED not turning on __or__ the one before it.
+If some LEDs aren't turning on,
+check the first LED not turning on __or__ the one before it.
 
 ![LED numbering on the PCB](https://user-images.githubusercontent.com/736191/40731604-62cee61e-646c-11e8-865f-829a48fa6be0.png)
 
 Here are some things to try out:
 
-- Make sure the LED is soldered correctly. Check the pads to see if it looks like they have a proper connection.
-- Check the LED orientation. Use the pictures above the see the correct orientation. Since the first LED is soldered with its back against the PCB, you might have to determinewhat the orientation should look like from the front using LEDs 7-27 (just double check that they are oriented correctly first).
-- If both of the above looks good, chances are the LED was damaged during soldering. Either replace it directly or use the diod mode of a multimeter to test the connectivity. One way to do this is by simply comparing to some of the other LEDs you have soldered. Choose two of the LED's pads (out of the four available) and compare the reading to that of some of the other LEDs (taking care to measure the same pads with the same needles of your multimeter). Work your way through all combinations of pads and needles. If the differ, you either have a broken LED or bad connectivity. Or simply desolder the LED directly, might be quicker. :)
+- Make sure the LED is soldered correctly.
+  Check the pads to see if it looks like they have a proper connection.
+- Check the LED orientation.
+  Use the pictures above the see the correct orientation.
+  Since the first LED is soldered with its back against the PCB,
+  you might have to determinewhat the orientation should look like from the front
+  using LEDs 7-27 (just double check that they are oriented correctly first).
+- If both of the above looks good, chances are the LED was damaged during soldering.
+  Either replace it directly or use the diod mode of a multimeter to test the connectivity.
+  One way to do this is by simply comparing to some of the other LEDs you have soldered.
+  Choose two of the LED's pads (out of the four available)
+  and compare the reading to that of some of the other LEDs
+  (taking care to measure the same pads with the same needles of your multimeter).
+  Work your way through all combinations of pads and needles.
+  If the differ, you either have a broken LED or bad connectivity.
+  Or simply desolder the LED directly, might be quicker. :)
 
 ### A full row/column of keys not working
 
-If a full row or column of keys is not working, then the culprit is most likely the connection between the PCB and the ProMicro. Check your soldering and make sure there's a proper connection and that you have soldered the ProMicro in the right set of holes. If soldering looks okay, then your ProMicro might be damaged. You can exclude the possibility of problems with the PCB, paths and diodes by short circuiting the pins on the ProMicro directly using a bit of wire. Connecting one row pin with one column pin should result in the corresponding key. Some PCBs have silkscreen print indicating which pin is which row or column, to make this process easier.
+If a full row or column of keys is not working,
+then the culprit is most likely the connection between the PCB and the ProMicro.
+Check your soldering and make sure there's a proper connection
+and that you have soldered the ProMicro in the right set of holes.
+If soldering looks okay, then your ProMicro might be damaged.
+You can exclude the possibility of problems with the PCB,
+paths and diodes by short circuiting the pins on the ProMicro directly,
+using a bit of wire.
+Connecting one row pin with one column pin should result in the corresponding key.
+Some PCBs have silkscreen print indicating which pin is which row or column,
+to make this process easier.
 
 ### Random key(s) not working
 
-If it is not a full row or column of keys that are not working, the issue is most likely that there's no connection between the key and the ProMicro. There are multiple places where the connection can get interupted:
+If it is not a full row or column of keys that are not working,
+the issue is most likely that there's no connection between the key and the ProMicro.
+There are multiple places where the connection can get interupted:
 
 - between keyswitch and PCB (if you have installed the switches)
 - between keyswitch and hotswap socket (if you use them)
@@ -248,8 +346,36 @@ If it is not a full row or column of keys that are not working, the issue is mos
 - in the diodes between the key and the ProMicro
 - in the paths inside the PCB
 
-If you have installed the keyswitches already, then check the soldering on the keyswitch. if you use hotswap sockets, check that you didn't accidentally bend one of the legs of the switch when inserting into the socket and that the socket soldering is alright.
+If you have installed the keyswitches already,
+then check the soldering on the keyswitch.
+if you use hotswap sockets,
+check that you didn't accidentally bend one of the legs of the switch
+when inserting into the socket and that the socket soldering is alright.
 
-Next, visually inspect the PCB. If it looks scratched or damaged anywhere along the path from ProMicro to diode to keyswitch, the path might be interrupted. If you find a spot that looks damaged, you can use some wire to bypass the section that is damaged (e.g. connecting the ProMicro directly to the first pad of the diode). If this fixes the key, then you can either opt to keep the wire permanently, or you can try to repair the path. The path can be repaired by carefully scraping off the paint from a section of the path that is okay on either side of the damaged part (use a small flat head screwdriver intended for electronics). Then clean carefully with alcohol and solder a new connection. Youtube might have some guides on how to do this.
+Next, visually inspect the PCB.
+If it looks scratched or damaged anywhere along the path
+from ProMicro to diode to keyswitch, the path might be interrupted.
+If you find a spot that looks damaged,
+you can use some wire to bypass the section that is damaged
+(e.g. connecting the ProMicro directly to the first pad of the diode).
+If this fixes the key, then you can either opt to keep the wire permanently,
+or you can try to repair the path.
+The path can be repaired by carefully scraping off the paint
+from a section of the path that is okay on either side of the damaged part
+(use a small flat head screwdriver intended for electronics).
+Then clean carefully with alcohol and solder a new connection.
+Youtube might have some guides on how to do this.
 
-If the PCB looks okay, then the diode would be the next thing to check. Begin by checking the soldering. If it looks okay, then the diode itself might be damaged. If you have a multimeter, use it to check the diode. The reading should be the same as for diodes connected to keys that are working (when measuring, remember that diodes have polarity). You can also use tweezers or a bit of soldering wire to connect the soldering pads on each side of the diode if you don't have a multimeter. Pressing the key (or short circuiting the pads where the key would go) after connecting the pads should make a key press being registered. If this is the case, or if you used the multimeter and got a different reading from the diode, then check your soldering and replace the diode if necessary.
+If the PCB looks okay, then the diode would be the next thing to check.
+Begin by checking the soldering.
+If it looks okay, then the diode itself might be damaged.
+If you have a multimeter, use it to check the diode.
+The reading should be the same as for diodes connected to keys that are working
+(when measuring, remember that diodes have polarity).
+You can also use tweezers or a bit of soldering wire
+to connect the soldering pads on each side of the diode if you don't have a multimeter.
+Pressing the key (or short circuiting the pads where the key would go)
+after connecting the pads should make a key press being registered.
+If this is the case, or if you used the multimeter
+and got a different reading from the diode,
+then check your soldering and replace the diode if necessary.

--- a/corne-classic/doc/buildguide_en.md
+++ b/corne-classic/doc/buildguide_en.md
@@ -1,7 +1,9 @@
 # Build Guide
 
 ## Parts
+
 ### Required
+
 | Item | Count | Remark |
 |:-|:-|:-|
 | PCB                   | 2      | |
@@ -13,12 +15,13 @@
 | Diode                 | 42     | You need SMD for low profile. |
 | Key Switch            | 42     | |
 | Key Cap               | 42     | 1u x 40,  1.5u x 2 |
-| Spacer M2 7.5mm         | 10     | use 3mm for low profile |
+| Spacer M2 7.5mm       | 10     | use 3mm for low profile |
 | Spacer M2 9mm or 11mm | 4      | |
 | Screw M2 4mm          | 28     | |
 | Rubber foot           | 10     | |
 
 ### Optional
+
 | Item | Count | Remark |
 |:-|:-|:-|
 | OLED Module           | 1 or 2 | |
@@ -30,6 +33,7 @@
 ![image](https://user-images.githubusercontent.com/736191/40734610-e1ca0136-6473-11e8-8ac7-7bfa4b843f93.png)
 
 ## Preparation
+
 If you build the firmware yourself, it will take some time to set up the environment, so it's best to start at the beginning. \
 For more information, please see https://github.com/foostan/crkbd/blob/master/doc/firmware_en.md.
 
@@ -84,12 +88,13 @@ LEDs are connected in the order of the number on the picture above. If it turns 
 __Note__ that the default Crkbd firmware has __LEDs turned off__, so you'll have to turn them on before you can test (see the firmware section for instructions how).
 
 ### Jumpers for OLED modules (optional)
+
 To use OLED modules, short circuit the jumper patterns.
 __Only short circuit the front side__
 
 ![image](https://user-images.githubusercontent.com/736191/40734778-56ded514-6474-11e8-8da7-3ebba048d62d.png)
 
-### TRRS socket, reset switch, OLED header sockets.
+### TRRS socket, reset switch, OLED header sockets
 
 Install TRRS sockets and reset switches as in the picture.
 For OLEDs, also implement pin sockets.
@@ -107,6 +112,7 @@ The ProMicro is then installed __in the set of holes that has a white frame on t
 The picture is the right hand side, but it's the same for the left hand side - pins into the through holes in the white frame as seen from the frontside, placing the ProMicro with its backside up.
 
 ### OLED Module
+
 Implement pin header onto the OLED modules, then insert them into the pin sockets.
 
 ![image](https://user-images.githubusercontent.com/736191/40888530-7420d1aa-6793-11e8-8813-9681c1411a21.png)
@@ -114,11 +120,9 @@ Implement pin header onto the OLED modules, then insert them into the pin socket
 Adjust the height of the spacer accordingly to the height of pin header.
 Most common pin header/socket and 11mm spacers are used in the picture.
 
-
 ### Use socket to Mount ProMicro
 
 With using sockets for mounting ProMicro, you can replace it easily when it breaks. Two methods are introduced here.
-
 
 #### Using Spring Loaded Header
 
@@ -126,16 +130,17 @@ Refer to [Helix Buildguide](https://github.com/MakotoKurauchi/helix/blob/master/
 
 ProMicro kit with spring loaded headers is available at Yusha-Kobo
 
-https://yushakobo.jp/shop/promicro-spring-pinheader/
+<https://yushakobo.jp/shop/promicro-spring-pinheader/>
 
 Using OLEDs available at Yusha-Kobo which come with low profile header, together with and 9mm spacers, you can build them think and gap-less.
 
 ![img_4141](https://user-images.githubusercontent.com/736191/41304818-2b65511e-6eac-11e8-9357-999ff14080ed.png)
 
 #### Using Pin Sockets
+
 Low profile pin sockets are available from Akizuki Denshi etc. Requires some work.
 
-http://akizukidenshi.com/catalog/g/gC-03138/
+<http://akizukidenshi.com/catalog/g/gC-03138/>
 
 Install a couple of 12x1 pin sockets on a breadboard.
 
@@ -155,11 +160,9 @@ Spring loaded headers can make the height lower.
 
 ![img_4134](https://user-images.githubusercontent.com/736191/41305254-53bc4522-6ead-11e8-83ed-c4c7c2787828.png)
 
-
 Comparing pin-headers in the picture. Headers come with OLED available at Yusha-Kobo are lower.
 
 ![img_4137](https://user-images.githubusercontent.com/736191/41305263-57e53dac-6ead-11e8-9b5d-5667bca5599e.png)
-
 
 ### Testing
 It is recommended to test the ProMicro and OLED modules before installing keyswitches because rework would be difficult after that.
@@ -177,31 +180,34 @@ If you have mounted LEDs, also make sure all of them are turned on. As note befo
 ![image](https://user-images.githubusercontent.com/736191/40888868-73028d36-6798-11e8-8246-0c9ca32711d6.png)
 
 ### Keyswitches and Top Plate
+
 Sandwich top-plate with PCB and key-switches.
 
 ![image](https://user-images.githubusercontent.com/736191/40888597-8a5bf7a0-6794-11e8-89e2-535c3f8381b9.png)
 
-
 ### Bottom Plate
+
 Use 3mm spacers for low-profile,
 Attach bottom plate to the PCB using 7.5mm (3mm for low-profile) spacers.
 Then attach six rubber feet.
 
-
 ![image](https://user-images.githubusercontent.com/736191/40888724-2892c24a-6796-11e8-8f38-a0a3d5e5440e.png)
 
 ### Keycaps
+
 Lastly install keycaps.
 
 ![lrg_dsc03895](https://user-images.githubusercontent.com/736191/40888756-c371e264-6796-11e8-8fc5-e842e8baf2b8.png)
 
-
 ## Firmware
+
 See below to flash the firmware to the ProMicro. \
-https://github.com/foostan/crkbd/blob/master/doc/firmware_en.md
+<https://github.com/foostan/crkbd/blob/master/doc/firmware_en.md>
 
 ### Turning LEDS on
+
 To turn the LEDs on, you have to edit the `rules.mk` file. If you use the default layout, it can be found here `keyboards/crkbd/keymaps/default/rules.mk`. Add the following line to the top of the file:
+
 ```
 RGBLIGHT_ENABLE = yes
 ```
@@ -209,25 +215,31 @@ RGBLIGHT_ENABLE = yes
 Compile and flash to both sides and all LEDs should turn on and __glow red__ if you have soldered everything correctly. If you run the default firmware and the LEDs turn a differrent color, the data to the LEDs is probably corrupted somewhere along the way. Check the LED before the first one turning a different color using the troubleshooting guide below.
 
 ## Troubleshooting
+
 Here are some tips and tricks on how to troubleshot a board that is not working.
 
 ### No LEDs turn on
+
 There are a number of things that might be wrong. First of all, make sure you have __turned on LED lighting in the firmware__. If that is the case, then chances are there might be a problem with the first LED. Try the suggestions in the next section.
 
 ### Some LEDs not turning on
+
 If some LEDs aren't turning on, check the first LED not turning on __or__ the one before it.
 
 ![LED numbering on the PCB](https://user-images.githubusercontent.com/736191/40731604-62cee61e-646c-11e8-865f-829a48fa6be0.png)
 
 Here are some things to try out:
+
 - Make sure the LED is soldered correctly. Check the pads to see if it looks like they have a proper connection.
 - Check the LED orientation. Use the pictures above the see the correct orientation. Since the first LED is soldered with its back against the PCB, you might have to determinewhat the orientation should look like from the front using LEDs 7-27 (just double check that they are oriented correctly first).
 - If both of the above looks good, chances are the LED was damaged during soldering. Either replace it directly or use the diod mode of a multimeter to test the connectivity. One way to do this is by simply comparing to some of the other LEDs you have soldered. Choose two of the LED's pads (out of the four available) and compare the reading to that of some of the other LEDs (taking care to measure the same pads with the same needles of your multimeter). Work your way through all combinations of pads and needles. If the differ, you either have a broken LED or bad connectivity. Or simply desolder the LED directly, might be quicker. :)
 
 ### A full row/column of keys not working
+
 If a full row or column of keys is not working, then the culprit is most likely the connection between the PCB and the ProMicro. Check your soldering and make sure there's a proper connection and that you have soldered the ProMicro in the right set of holes. If soldering looks okay, then your ProMicro might be damaged. You can exclude the possibility of problems with the PCB, paths and diodes by short circuiting the pins on the ProMicro directly using a bit of wire. Connecting one row pin with one column pin should result in the corresponding key. Some PCBs have silkscreen print indicating which pin is which row or column, to make this process easier.
 
 ### Random key(s) not working
+
 If it is not a full row or column of keys that are not working, the issue is most likely that there's no connection between the key and the ProMicro. There are multiple places where the connection can get interupted:
 
 - between keyswitch and PCB (if you have installed the switches)

--- a/corne-classic/doc/buildguide_en.md
+++ b/corne-classic/doc/buildguide_en.md
@@ -42,8 +42,8 @@ For more information, please see https://github.com/foostan/crkbd/blob/master/do
 PCB is reversible; use one for the left hand side and the other for the right.
 
 ### Diodes
-__For non Low Profile keyswitches__
 
+#### For non Low Profile keyswitches
 Solder diodes as indicated in the picture. You can place it on either side, but front side is recommended if you implement under-glow LED. You can use SMD diodes too.
 
 ![image](https://user-images.githubusercontent.com/736191/40736513-306a0976-6479-11e8-8f98-a88073919a71.png)
@@ -55,7 +55,7 @@ Diode has polarity; make sure to match the polarity with PCB silkscreen.
 
 ![image](https://user-images.githubusercontent.com/736191/40735282-bac94180-6475-11e8-96f9-1d1cc43b1ee9.png)
 
-__For Low Profile Keyswitches__
+#### For Low Profile Keyswitches
 
 If you use low profile keyswitches, you have to implement SMD diodes __on the back side__.
 Otherwise, diodes will interfere with top plate.

--- a/corne-classic/doc/buildguide_jp.md
+++ b/corne-classic/doc/buildguide_jp.md
@@ -1,7 +1,9 @@
 # Build Guide
 
 ## 部品
+
 ### 必須
+
 | 名前 | 数 | 備考 |
 |:-|:-|:-|
 | PCB | 2枚 | |
@@ -19,6 +21,7 @@
 | クッションゴム | 10個 | |
 
 ### オプション
+
 | 名前 | 数 | 備考 |
 |:-|:-|:-|
 | OLEDモジュール | 1 ~ 2枚 | |
@@ -30,15 +33,17 @@
 ![image](https://user-images.githubusercontent.com/736191/40734610-e1ca0136-6473-11e8-8ac7-7bfa4b843f93.png)
 
 ## 事前準備
+
 ファームウェアを自分でビルドする場合は環境を整備するのに時間がかかるのではじめに取り掛かっておくことをおすすめします。\
-詳しくは https://github.com/foostan/crkbd/blob/master/doc/firmware_jp.md を参照してください。
+詳しくは <https://github.com/foostan/crkbd/blob/master/doc/firmware_jp.md> を参照してください。
 
 ## 実装
 
 PCBはリバーシブルになっているので、最初にどちらを左用/右用にするか決めます。
 
 ### ダイオード
-__ロープロファイルのキースイッチを使わない場合__
+
+#### ロープロファイルのキースイッチを使わない場合
 
 写真の位置にダイオードを実装します。
 どちらの面に実装するかは好みですが、Undergrow LEDを実装する場合は、干渉をさけるため表面に実装することをおすすめします。
@@ -52,7 +57,7 @@ __ロープロファイルのキースイッチを使わない場合__
 
 ![image](https://user-images.githubusercontent.com/736191/40735282-bac94180-6475-11e8-96f9-1d1cc43b1ee9.png)
 
-__ロープロファイルのキースイッチを使う場合__
+#### ロープロファイルのキースイッチを使う場合
 
 ロープロファイルスイッチを利用する場合は、表面実装タイプのダイオードを利用し、必ず __裏面に実装してください__ 。表面に実装してしまうとトッププレートがダイオードと干渉してしまいます。
 
@@ -75,6 +80,7 @@ __ロープロファイルのキースイッチを使う場合__
 LEDの点灯チェックを行う場合は、上記写真の番号どおりにつながっているため、途中までしか点灯しない場合は点灯しないLEDか、その一つ手前のLEDの実装ミスの可能性が高いので確認してみてください。
 
 ### OLEDモジュールのためのジャンパ(オプション)
+
 OLEDモジュールを利用する場合は下記のようにジャンパします。
 なお __表面のみジャンパしてください__ 。
 
@@ -88,12 +94,14 @@ OLEDモジュールを利用する場合は下記のようにジャンパしま�
 ![image](https://user-images.githubusercontent.com/736191/40736856-1bda2b84-647a-11e8-988b-dc45f2c76a38.png)
 
 ### ProMicro
+
 ピンヘッダを白い枠に当てはめるように実装し、そこにProMicroの裏面を上にして実装します。
 なお下記の写真は右手用ですが、左手用も同様に白枠にピンヘッダを実装し、ProMicroの裏面を上にして実装します。
 
 ![image](https://user-images.githubusercontent.com/736191/40737973-3f404de4-647d-11e8-84fe-37f3a34e4c53.png)
 
 ### OLEDモジュール
+
 OLEDモジュールにピンヘッダを実装し、ピンソケットに差し込みます。
 
 ![image](https://user-images.githubusercontent.com/736191/40888530-7420d1aa-6793-11e8-8813-9681c1411a21.png)
@@ -107,23 +115,25 @@ ProMicroをソケット化をすることでProMicroが故障してしまった�
 2パターンのソケット化を紹介します。
 
 #### スプリングヘッダを利用したソケット化
+
 ソケット化を可能とする特殊なピンヘッダを利用する方法です。
 利用方法はHelixのビルドガイドを参考にしてください。
-https://github.com/MakotoKurauchi/helix/blob/master/Doc/buildguide_jp.md#pro-micro
+<https://github.com/MakotoKurauchi/helix/blob/master/Doc/buildguide_jp.md#pro-micro>
 
 スプリングヘッダとProMicroのセットは遊舎工房にて購入することが可能です。
 
-https://yushakobo.jp/shop/promicro-spring-pinheader/
+<https://yushakobo.jp/shop/promicro-spring-pinheader/>
 
 同じく遊舎工房で購入可能なOLEDについてくるピンヘッダを利用すると以下のように隙間なくきれいに収まります。また9mmのスペーサーを利用することができるのでより薄い仕上がりとなります。
 
 ![img_4141](https://user-images.githubusercontent.com/736191/41304818-2b65511e-6eac-11e8-9357-999ff14080ed.png)
 
 #### ピンソケットを利用したソケット化
+
 秋月電子等で購入可能な背の低いピンソケットを利用した方法です。
 多少の工作が必要となります。
 
-http://akizukidenshi.com/catalog/g/gC-03138/
+<http://akizukidenshi.com/catalog/g/gC-03138/>
 
 12個連結ピンソケット2つ用意し、ブレッドボード等に固定します。
 
@@ -148,8 +158,8 @@ ProMicroに付属しているピンヘッダProMicroを挟むようにして上�
 
 ![img_4137](https://user-images.githubusercontent.com/736191/41305263-57e53dac-6ead-11e8-9b5d-5667bca5599e.png)
 
-
 ### 動作確認
+
 キースイッチを付けると何か問題があった場合に修正が難しくなるため、ProMicroとOLEDモジュールを付けた段階で動作確認をすることをおすすめします。
 
 動作確認をする場合は先に下記の「ファームウェア」の章を参考にしてcrkbd用のファームウェアをProMicroに入れてください。
@@ -163,23 +173,27 @@ LEDを実装した場合はすべて点灯することを確認します。
 ![image](https://user-images.githubusercontent.com/736191/40888868-73028d36-6798-11e8-8246-0c9ca32711d6.png)
 
 ### キースイッチおよびトッププレート
+
 キースイッチとPCBの間にトッププレートを挟んで表面に実装します。
 
 ![image](https://user-images.githubusercontent.com/736191/40888597-8a5bf7a0-6794-11e8-89e2-535c3f8381b9.png)
 
 ### ボトムプレート
+
 ロープロの場合は4.5mmのスペーサー、それ以外は7.5mmのスペーサーを取り付けたあとにボトムプレートを取り付けます。
 またクッションゴムを6つ付けます。
 
 ![image](https://user-images.githubusercontent.com/736191/40888724-2892c24a-6796-11e8-8f38-a0a3d5e5440e.png)
 
 ### キーキャップ
+
 最後にキーキャップを付けて実装は完了です。
 
 ![lrg_dsc03895](https://user-images.githubusercontent.com/736191/40888756-c371e264-6796-11e8-8fc5-e842e8baf2b8.png)
 
 ## ファームウェア
+
 下記を参照しファームウェアをProMicroに書き込みます。\
-https://github.com/foostan/crkbd/blob/master/doc/firmware_jp.md
+<https://github.com/foostan/crkbd/blob/master/doc/firmware_jp.md>
 
 以上で完成です。

--- a/corne-light/doc/v1/buildguide_jp.md
+++ b/corne-light/doc/v1/buildguide_jp.md
@@ -2,7 +2,6 @@
 
 こちらは Corne Light のビルドガイドになります。
 
-
 ## 部品
 
 <table>
@@ -110,11 +109,14 @@
 </table>
 
 ## 事前準備
+
 ファームウェアを自分でビルドする場合は環境を整備するのに時間がかかるのではじめに取り掛かっておくことをおすすめします。\
-詳しくは https://github.com/foostan/crkbd/blob/master/doc/firmware_jp.md を参照してください。
+詳しくは <https://github.com/foostan/crkbd/blob/master/doc/firmware_jp.md> を参照してください。
 
 ## 実装
+
 ### PCBの切り離し
+
 裏表を確認して左右のPCBを切り離します(写真は表です)。
 
 <img alt="assembly-pcb" src="https://user-images.githubusercontent.com/736191/69554624-6c78b980-0fe5-11ea-9828-3be0af9f27af.JPG" width="100%">
@@ -159,6 +161,7 @@
 <img alt="assembly-diodes-7" src="https://user-images.githubusercontent.com/736191/69554635-6da9e680-0fe5-11ea-9ee3-b503bc0fcc83.JPG" width="100%">
 
 ### TRRSジャック、リセットスイッチ、ピンソケット
+
 指定の位置に取り付けます。
 ※ 右手側も同じ位置に取り付けます(表裏の間違いに気を付けてください)。
 
@@ -171,8 +174,9 @@
 <img alt="assembly-promicro-oled" src="https://user-images.githubusercontent.com/736191/69554644-6e427d00-0fe5-11ea-8c6b-9aaa3d2c3f6c.JPG" width="100%">
 
 ### ファームウェアの書き込み
+
 下記を参照しファームウェアをProMicroに書き込みます。\
-https://github.com/foostan/crkbd/blob/master/doc/firmware_jp.md
+<https://github.com/foostan/crkbd/blob/master/doc/firmware_jp.md>
 
 ### 動作確認
 
@@ -212,15 +216,10 @@ M2 7.5mm スペーサーを用いてボトムプレートを取り付けます�
 
 <img alt="assembly-plates-3" src="https://user-images.githubusercontent.com/736191/69554661-70a4d700-0fe5-11ea-85c1-acae90ea7725.JPG" width="100%">
 
-
 ## 完成
+
 キーキャップを取り付けて完成です。
 
 <img alt="assembly-finished-1" src="https://user-images.githubusercontent.com/736191/69654854-d615c800-10b8-11ea-8903-ebf019d7b125.png" width="100%">
 <img alt="assembly-finished-2" src="https://user-images.githubusercontent.com/736191/69654882-df069980-10b8-11ea-8efe-069b68db3bc0.png" width="100%">
-
-
-
-
-
 

--- a/corne-light/doc/v2/buildguide_low_edition_jp.md
+++ b/corne-light/doc/v2/buildguide_low_edition_jp.md
@@ -7,8 +7,10 @@
 ![corne-light-low-edition-003](assets/corne-light-low-edition-003.jpg)
 
 ## 部品
+
 ### 必須
-| 名前 | 数 | 備考 | 
+
+| 名前 | 数 | 備考 |
 |:-|:-|:-|
 | PCB | 1セット | |
 | トッププレート(アクリル) 2mm | 2枚 | |
@@ -26,6 +28,7 @@
 | Micro USBケーブル | 1本 | |
 
 ### オプション
+
 | 名前 | 数 | 備考 |
 |:-|:-|:-|
 | OLEDモジュール | 2枚 | |
@@ -33,8 +36,9 @@
 | OLEDモジュール用ピンソケット 4連 2.5mm | 2つ | |
 
 ## 事前準備
+
 ファームウェアを自分でビルドする場合は環境を整備するのに時間がかかるのではじめに取り掛かっておくことをおすすめします。\
-詳しくは https://github.com/foostan/crkbd/blob/master/doc/firmware_jp.md を参照してください。
+詳しくは <https://github.com/foostan/crkbd/blob/master/doc/firmware_jp.md> を参照してください。
 
 ## 確認
 
@@ -53,6 +57,7 @@ PCBは製造の都合上フレームが付いた状態となっています。
 ![confirm_remove_frame](assets/confirm_remove_frame.jpg)
 
 ## 組み立て
+
 ### ダイオード
 
 SMD部品のダイオードのはんだづけを行います。
@@ -102,6 +107,7 @@ SMD部品を取り付けるコツですが、まずは予備ハンダとして�
 ずれやすい部品なので、手で部品を抑えながらはんだづけするか、マスキングテープ等で固定してからはんだづけするときれいに付きます。
 
 ### ProMicro
+
 ProMicroを下記のような向きではんだ付けします
 
 ![build_promicro](assets/build_promicro.jpg)
@@ -112,16 +118,19 @@ ProMicroを下記のような向きではんだ付けします
 ![build_promicro_conthrough](assets/build_promicro_conthrough.jpg)
 
 ### OLEDモジュール
+
 OLED用のピンソケットにピンヘッダを先に差し込み、その後からピンヘッダとOLEDモジュールをはんだづけします。
 このときOLEDモジュールが浮きやすいので指で押さえつけながら浮かないように気をつけます。
 
 ![build_oled](assets/build_oled.jpg)
 
 ### ファームウェア
+
 下記を参照しファームウェアをProMicroに書き込みます。\
-https://github.com/foostan/crkbd/blob/master/doc/firmware_jp.md
+<https://github.com/foostan/crkbd/blob/master/doc/firmware_jp.md>
 
 ### 動作確認
+
 ProMicroとOLEDモジュールを付けた段階で動作確認をすることをおすすめします。
 一番最後にやると問題の切り分けが難しくなります。
 

--- a/doc/firmware_en.md
+++ b/doc/firmware_en.md
@@ -6,8 +6,9 @@
 There are several ways to flash the firmware, but using [QMK Toolbox](https://github.com/qmk/qmk_toolbox) is the easiest way.
 
 ### Download QMK Toolbox
+
 Download QMK Toolbox from the following link.\
-https://github.com/qmk/qmk_toolbox/releases/
+<https://github.com/qmk/qmk_toolbox/releases/>
 
 ![qmk_toolbox_download](assets/qmk_toolbox_download.jpg)
 
@@ -82,7 +83,7 @@ It can be used by flashing the firmware for VIA as described above.
 ### Download VIA
 
 Download VIA from the following link.\
-https://github.com/the-via/releases/releases/
+<https://github.com/the-via/releases/releases/>
 
 ![via_download](assets/via_download.jpg)
 

--- a/doc/firmware_en.md
+++ b/doc/firmware_en.md
@@ -1,9 +1,9 @@
-
 # Firmware
 
 ## Flash the firmware
 
-There are several ways to flash the firmware, but using [QMK Toolbox](https://github.com/qmk/qmk_toolbox) is the easiest way.
+There are several ways to flash the firmware,
+but using [QMK Toolbox](https://github.com/qmk/qmk_toolbox) is the easiest way.
 
 ### Download QMK Toolbox
 
@@ -29,7 +29,8 @@ And enable the check box for "**Auto-Flash**".
 
 ![qmk_toolbox_flash](assets/qmk_toolbox_flash.jpg)
 
-With the keyboard connected via USB, press the reset button to start flashing the firmware. \
+With the keyboard connected via USB,
+press the reset button to start flashing the firmware. \
 If you see the message, it's done.
 
 ![qmk_toolbox_flashed](assets/qmk_toolbox_flashed.jpg)
@@ -98,8 +99,10 @@ When VIA is opened with the keyboard plugged in, the following window will appea
 
 In this screen, you can change the key map.
 
-There are several types of keys that can be changed and you can find them in the "1" area.
-If you want to change the key, click on "2" to change the key and "3" to select the key you want to change.
+There are several types of keys that can be changed
+and you can find them in the "1" area.
+If you want to change the key,
+click on "2" to change the key and "3" to select the key you want to change.
 VIA instantly changes the keymap.
 
 ![via_keymap_configure](assets/via_keymap_configure.jpg)
@@ -108,7 +111,8 @@ VIA instantly changes the keymap.
 
 In this screen, you can test the operation of the keymap.
 
-You can confirm that the key is set correctly by checking that the color of the key you press changes.
+You can confirm that the key is set correctly
+by checking that the color of the key you press changes.
 
 ![via_keymap_tester](assets/via_keymap_tester.jpg)
 

--- a/doc/firmware_jp.md
+++ b/doc/firmware_jp.md
@@ -5,8 +5,9 @@
 ファームウェアの書き込み方法はいくつか用意されていますが、[QMK Toolbox](https://github.com/qmk/qmk_toolbox) を利用する方法が手軽です。
 
 ### QMK Toolbox のダウンロード
+
 下記のURLから最新版の QMK Toolbox をダウンロードします。\
-https://github.com/qmk/qmk_toolbox/releases/
+<https://github.com/qmk/qmk_toolbox/releases/>
 
 ![qmk_toolbox_download](assets/qmk_toolbox_download.jpg)
 
@@ -36,7 +37,7 @@ QMK Toolbox の 「**Open**」 からダウンロードしたファイルを指�
 
 ### (オプション) 自分でファームウェアをビルドする場合
 
-https://docs.qmk.fm/#/newbs_getting_started こちらを参照して頂き、ファームウェアを書き込む環境を用意します。
+<https://docs.qmk.fm/#/newbs_getting_started> こちらを参照して頂き、ファームウェアを書き込む環境を用意します。
 
 環境ができましたら、下記コマンドで Crkbd 用にファームウェアをビルドします。
 
@@ -71,8 +72,9 @@ Corne Keyboard は [VIA](https://caniusevia.com/) に対応しています。\
 上記の手順で VIA 用のファームウェアを書き込むことで利用することできます。
 
 ### VIA のダウンロード
+
 下記のURLから最新版の VIA をダウンロードします。\
-https://github.com/the-via/releases/releases/
+<https://github.com/the-via/releases/releases/>
 
 ![via_download](assets/via_download.jpg)
 


### PR DESCRIPTION
No actual content changes apart from a fixed URL (went from the English version of the guide to an external Japanese version, instead of the also present English version).