### PR TITLE
Correct minor typo in buildguide_en.md

### DIFF
--- a/corne-chocolate/doc/buildguide_en.md
+++ b/corne-chocolate/doc/buildguide_en.md
@@ -120,7 +120,7 @@ When using an OLED module, use solder as jumpers (4 times per side) as follows.
 If the jumper doesn't work,
 you probably have a small amount of solder,
 or the flux has vaporized.
-If so, you cna fix the jumper by applying more solder or separate flux.
+If so, you can fix the jumper by applying more solder or separate flux.
 
 ### Pro Micro
 


### PR DESCRIPTION
There was a _cna_ where a _can_ should be.