### PR TITLE
Fix wrong statements about the number of WS2812B in v3 buildguide

### DIFF
--- a/corne-cherry/doc/v3/buildguide_en.md
+++ b/corne-cherry/doc/v3/buildguide_en.md
@@ -152,7 +152,7 @@ In addition, his PCB of Corne has the same mounting orientation of his WS2812B.
 
 ![build_led_undergrow](assets/build_led_undergrow.jpg)
 
-He soldered a total of 8 pieces on the left and right, and he completed the WS2812B.
+He soldered a total of 12 pieces on the left and right, and he completed the WS2812B.
 
 ![build_led_undergrow_overview](assets/build_led_undergrow_overview.jpg)
 

--- a/corne-cherry/doc/v3/buildguide_jp.md
+++ b/corne-cherry/doc/v3/buildguide_jp.md
@@ -122,7 +122,7 @@ __TIPS: SMD部品を取り付けるコツ__ で紹介したように、予備ハ
 
 ![build_led_undergrow](assets/build_led_undergrow.jpg)
 
-左右合わせて計8個はんだづけして WS2812B は完了です。
+左右合わせて計12個はんだづけして WS2812B は完了です。
 
 ![build_led_undergrow_overview](assets/build_led_undergrow_overview.jpg)
 


### PR DESCRIPTION
Hi, now I'm building my Corne Cherry v3 and I might have found a wrong statement in buidlguide.
Actually the number of soldered WS2812B seems 12, but buildguide says 8.