### PR TITLE
joined nodes of alp plate outline path

### DIFF
--- a/plates/alps/top.svg
+++ b/plates/alps/top.svg
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    sodipodi:docname="top.svg"
    id="svg255"
    version="1.2"
    viewBox="0 0 420.945 595.276"
    height="595.276pt"
    width="420.945pt"
-   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)">
+   inkscape:version="1.1 (c68e22c387, 2021-05-23)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <metadata
      id="metadata261">
     <rdf:RDF>
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -30,7 +30,7 @@
      id="defs259" />
   <sodipodi:namedview
      id="namedview257"
-     inkscape:window-height="1057"
+     inkscape:window-height="1017"
      inkscape:window-width="1920"
      inkscape:pageshadow="2"
      inkscape:pageopacity="0"
@@ -42,645 +42,283 @@
      pagecolor="#ffffff"
      inkscape:document-rotation="0"
      showgrid="false"
-     inkscape:zoom="0.5606643"
-     inkscape:cx="553.49556"
-     inkscape:cy="580.56054"
+     inkscape:zoom="0.70710678"
+     inkscape:cx="222.73864"
+     inkscape:cy="362.74578"
      inkscape:window-x="1912"
      inkscape:window-y="-8"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg255" />
+     inkscape:current-layer="svg255"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="pt" />
   <g
-     id="surface1"
-     style="stroke-width:0.99974998;stroke-miterlimit:4;stroke-dasharray:none">
-    <path
-       id="path2"
-       transform="matrix(1,0,0,-1,403.2047,41.3931)"
-       d="M -0.001575 -0.00143125 L -0.001575 -166.5444 C -0.001575 -167.634244 -1.181263 -168.317837 -2.126575 -167.770962 L -55.185169 -137.149869 C -55.626575 -136.895962 -55.896106 -136.427212 -55.896106 -135.923306 L -55.896106 -0.0053375 C -55.896106 0.775913 -55.259388 1.408725 -54.478138 1.412631 L -1.415638 1.416538 C -0.634388 1.416538 -0.001575 0.783725 -0.001575 -0.00143125 Z M -0.001575 -0.00143125 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path4"
-       transform="matrix(1,0,0,-1,337.9239,182.77)"
-       d="M 0.00188125 0.00046875 C 0.0214125 -0.749531 0.392506 -1.444844 0.997975 -1.88625 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path6"
-       transform="matrix(1,0,0,-1,393.6324,221.0796)"
-       d="M 0.0004125 0.001475 C 1.21135 1.79835 0.738694 4.243663 -1.062088 5.4546 L -1.077713 5.466319 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path8"
-       transform="matrix(1,0,0,-1,392.5508,215.607)"
-       d="M -0.00001875 0.00153125 L -53.632831 30.95075 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path10"
-       transform="matrix(1,0,0,-1,353.1509,282.9771)"
-       d="M 0.00144375 0.0005375 C 1.798319 -1.214306 4.243631 -0.737744 5.458475 1.063038 C 5.458475 1.066944 5.462381 1.07085 5.466287 1.074756 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path12"
-       transform="matrix(1,0,0,-1,312.6324,259.5601)"
-       d="M 0.0004125 0.00150625 C -0.605056 0.181194 -1.22615 0.306194 -1.855056 0.368694 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path14"
-       transform="matrix(1,0,0,-1,358.6099,281.898)"
-       d="M -0.000525 -0.0004375 L 35.022912 60.819875 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path16"
-       transform="matrix(1,0,0,-1,312.6309,259.5562)"
-       d="M 0.0019125 0.0015125 L 40.513631 -23.41255 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path18"
-       transform="matrix(1,0,0,-1,206.8272,245.6675)"
-       d="M 0.000925 -0.00046875 L 103.946237 -13.52 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path20"
-       transform="matrix(1,0,0,-1,205.8267,245.2554)"
-       d="M 0.001425 0.00149375 C 0.26705 -0.264131 0.626425 -0.416475 1.001425 -0.416475 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path22"
-       transform="matrix(1,0,0,-1,175.939,204.2671)"
-       d="M -0.0015 0.001475 L 29.885219 -40.9829 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path24"
-       transform="matrix(1,0,0,-1,337.9244,39.4448)"
-       d="M 0.00138125 -0.0005125 L -0.00643125 -143.324731 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path26"
-       transform="matrix(1,0,0,-1,337.9307,39.4497)"
-       d="M -0.0010125 0.00048125 C -0.0010125 0.781731 -0.633825 1.41845 -1.415075 1.41845 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path28"
-       transform="matrix(1,0,0,-1,175.941,204.2749)"
-       d="M 0.00040625 0.0014625 C -0.265219 0.267088 -0.624594 0.415525 -1.0035 0.415525 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path30"
-       transform="matrix(1,0,0,-1,17.6163,202.4419)"
-       d="M 0.0008875 0.00049375 C 0.0008875 -0.784662 0.6337 -1.417475 1.418856 -1.417475 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path32"
-       transform="matrix(1,0,0,-1,19.0338,44.4106)"
-       d="M 0.00135625 0.00044375 C -0.7838 0.00044375 -1.416613 -0.636275 -1.416613 -1.417525 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path34"
-       transform="matrix(1,0,0,-1,123.9156,44.4106)"
-       d="M -0.0015375 0.00044375 C 0.783619 0.00044375 1.416431 0.633256 1.416431 1.418413 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path36"
-       transform="matrix(1,0,0,-1,126.7501,30.9458)"
-       d="M -0.0001 0.0004875 C -0.78135 0.0004875 -1.418069 -0.636231 -1.418069 -1.417481 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path38"
-       transform="matrix(1,0,0,-1,177.7735,30.9458)"
-       d="M -0.0000625 0.0004875 C 0.781188 0.0004875 1.417906 0.6333 1.417906 1.418456 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path40"
-       transform="matrix(1,0,0,-1,180.6085,24.5679)"
-       d="M 0.000875 0.00149375 C -0.784281 0.00149375 -1.417094 -0.635225 -1.417094 -1.416475 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path42"
-       transform="matrix(1,0,0,-1,230.2149,25.9858)"
-       d="M -0.00005625 0.001425 C -0.00005625 0.782675 -0.632869 1.419394 -1.418025 1.419394 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path44"
-       transform="matrix(1,0,0,-1,230.2149,29.5288)"
-       d="M -0.00005625 0.00145625 C -0.00005625 -0.7837 0.632756 -1.416512 1.417913 -1.416512 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path46"
-       transform="matrix(1,0,0,-1,284.0728,32.3628)"
-       d="M 0.00141875 -0.00048125 C 0.00141875 0.780769 -0.6353 1.417488 -1.41655 1.417488 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path48"
-       transform="matrix(1,0,0,-1,284.0728,36.6157)"
-       d="M 0.00141875 -0.0014875 C 0.00141875 -0.782737 0.634231 -1.41555 1.415481 -1.41555 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path50"
-       transform="matrix(1,0,0,-1,174.938,203.857)"
-       d="M -0.0005 0.00153125 L -155.910656 0.00153125 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path52"
-       transform="matrix(1,0,0,-1,17.6114,45.8247)"
-       d="M 0.00188125 0.00048125 L 0.00188125 -156.6128 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path54"
-       transform="matrix(1,0,0,-1,123.9117,44.4058)"
-       d="M -0.00154375 -0.00045 L -104.88045 -0.00045 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path56"
-       transform="matrix(1,0,0,-1,125.3301,32.3599)"
-       d="M 0.00193125 0.000525 L 0.00193125 -10.628381 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path58"
-       transform="matrix(1,0,0,-1,177.7676,30.9419)"
-       d="M 0.00193125 0.00049375 L -51.0176 0.00049375 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path60"
-       transform="matrix(1,0,0,-1,179.1861,25.981)"
-       d="M 0.0014 0.00053125 L 0.0014 -3.542438 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path62"
-       transform="matrix(1,0,0,-1,228.794,24.563)"
-       d="M -0.00103125 0.0005 L -48.188531 0.0005 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path64"
-       transform="matrix(1,0,0,-1,230.2125,29.5239)"
-       d="M -0.0015625 0.0004625 L -0.0015625 3.543431 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path66"
-       transform="matrix(1,0,0,-1,282.65,30.9419)"
-       d="M -0.0015625 0.00049375 L -51.017188 0.00049375 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path68"
-       transform="matrix(1,0,0,-1,284.0684,36.6079)"
-       d="M 0.0019125 -0.001475 L 0.0019125 4.248525 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path70"
-       transform="matrix(1,0,0,-1,336.5132,38.0269)"
-       d="M -0.00148125 -0.00044375 L -51.024919 -0.00044375 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path72"
-       transform="matrix(1,0,0,-1,19.0743,328.4575)"
-       d="M -0.00008125 0.00046875 L -0.00008125 -166.546406 C -0.00008125 -167.63625 1.179606 -168.319844 2.124919 -167.772969 L 55.187419 -137.151875 C 55.624919 -136.897969 55.89445 -136.429219 55.89445 -135.921406 L 55.89445 -0.00734375 C 55.89445 0.773906 55.261637 1.410625 54.480387 1.410625 L 1.417887 1.418438 C 0.636637 1.418438 -0.00008125 0.781719 -0.00008125 0.00046875 Z M -0.00008125 0.00046875 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path74"
-       transform="matrix(1,0,0,-1,84.3555,469.8355)"
-       d="M -0.00003125 -0.0004375 C -0.0234687 -0.750437 -0.390656 -1.44575 -1.000031 -1.88325 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path76"
-       transform="matrix(1,0,0,-1,28.647,508.145)"
-       d="M 0.0014375 0.00046875 C -1.213406 1.80125 -0.736844 4.242656 1.063937 5.4575 L 1.075656 5.465313 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path78"
-       transform="matrix(1,0,0,-1,29.7286,502.6724)"
-       d="M 0.00186875 0.000525 L 53.634681 30.95365 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path80"
-       transform="matrix(1,0,0,-1,69.1285,570.0415)"
-       d="M 0.00040625 -0.00146875 C -1.800375 -1.212406 -4.245687 -0.73975 -5.456625 1.061031 C -5.460531 1.064938 -5.464437 1.07275 -5.464437 1.076656 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path82"
-       transform="matrix(1,0,0,-1,109.647,546.6245)"
-       d="M 0.0014375 -0.0005 C 0.606906 0.183094 1.228 0.304188 1.856906 0.366688 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path84"
-       transform="matrix(1,0,0,-1,63.669,568.9624)"
-       d="M -0.00103125 0.0014625 L -35.020563 60.817869 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path86"
-       transform="matrix(1,0,0,-1,109.6485,546.6206)"
-       d="M -0.0000625 -0.00049375 L -40.515687 -23.414556 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path88"
-       transform="matrix(1,0,0,-1,215.4522,532.7319)"
-       d="M 0.000925 0.00143125 L -103.944388 -13.522006 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path90"
-       transform="matrix(1,0,0,-1,216.4522,532.3208)"
-       d="M 0.000925 0.0004875 C -0.2647 -0.265137 -0.624075 -0.413575 -1.002981 -0.413575 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path92"
-       transform="matrix(1,0,0,-1,246.3404,491.3325)"
-       d="M -0.00055625 0.00046875 L -29.887275 -40.983906 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path94"
-       transform="matrix(1,0,0,-1,84.355,326.5103)"
-       d="M 0.00046875 -0.00141875 L 0.00828125 -143.321731 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path96"
-       transform="matrix(1,0,0,-1,84.3482,326.5152)"
-       d="M -0.00054375 -0.000425 C -0.00054375 0.784731 0.632269 1.417544 1.417425 1.417544 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path98"
-       transform="matrix(1,0,0,-1,246.338,491.3394)"
-       d="M 0.00184375 -0.00044375 C 0.267469 0.265181 0.626844 0.413619 1.001844 0.413619 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path100"
-       transform="matrix(1,0,0,-1,404.6631,489.5073)"
-       d="M 0.0009625 -0.0005125 C 0.0009625 -0.781762 -0.635756 -1.418481 -1.417006 -1.418481 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path102"
-       transform="matrix(1,0,0,-1,403.2452,331.4761)"
-       d="M 0.00089375 -0.0004625 C 0.782144 -0.0004625 1.418862 -0.633275 1.418862 -1.418431 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path104"
-       transform="matrix(1,0,0,-1,298.3638,331.4761)"
-       d="M -0.00051875 -0.0004625 C -0.781769 -0.0004625 -1.418488 0.636256 -1.418488 1.417506 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path106"
-       transform="matrix(1,0,0,-1,295.5294,318.0113)"
-       d="M 0.00185 -0.00041875 C 0.7831 -0.00041875 1.415912 -0.633231 1.415912 -1.418387 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path108"
-       transform="matrix(1,0,0,-1,244.5059,318.0113)"
-       d="M 0.0019125 -0.00041875 C -0.783244 -0.00041875 -1.416056 0.632394 -1.416056 1.41755 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path110"
-       transform="matrix(1,0,0,-1,241.671,311.6324)"
-       d="M 0.000875 -0.0004125 C 0.782125 -0.0004125 1.418844 -0.637131 1.418844 -1.418381 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path112"
-       transform="matrix(1,0,0,-1,192.0645,313.0503)"
-       d="M 0.00190625 -0.00048125 C 0.00190625 0.780769 0.634719 1.417488 1.415969 1.417488 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path114"
-       transform="matrix(1,0,0,-1,192.0645,316.5933)"
-       d="M 0.00190625 -0.00045 C 0.00190625 -0.7817 -0.634812 -1.418419 -1.416062 -1.418419 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path116"
-       transform="matrix(1,0,0,-1,138.2066,319.4283)"
-       d="M 0.00043125 -0.0013875 C 0.00043125 0.783769 0.633244 1.416581 1.4184 1.416581 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path118"
-       transform="matrix(1,0,0,-1,138.2066,323.6802)"
-       d="M 0.00043125 0.0005125 C 0.00043125 -0.784644 -0.636287 -1.417456 -1.417537 -1.417456 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path120"
-       transform="matrix(1,0,0,-1,247.3409,490.9224)"
-       d="M -0.00105625 0.000525 L 155.9091 0.000525 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path122"
-       transform="matrix(1,0,0,-1,404.668,332.8892)"
-       d="M -0.00003125 -0.001425 L -0.00003125 -156.614706 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path124"
-       transform="matrix(1,0,0,-1,298.3672,331.4712)"
-       d="M -0.0000125 -0.00145625 L 104.8828 -0.00145625 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path126"
-       transform="matrix(1,0,0,-1,296.9488,319.4253)"
-       d="M 0.00041875 -0.00048125 L 0.00041875 -10.625481 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path128"
-       transform="matrix(1,0,0,-1,244.5113,318.0074)"
-       d="M 0.00041875 -0.0004125 L 51.01995 -0.0004125 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path130"
-       transform="matrix(1,0,0,-1,243.0928,313.0464)"
-       d="M 0.00095 -0.000475 L 0.00095 -3.543444 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path132"
-       transform="matrix(1,0,0,-1,193.4849,311.6275)"
-       d="M -0.000525 -0.00140625 L 48.190881 -0.00140625 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path134"
-       transform="matrix(1,0,0,-1,192.0665,316.5884)"
-       d="M -0.00009375 -0.00144375 L -0.00009375 3.541525 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path136"
-       transform="matrix(1,0,0,-1,139.629,318.0074)"
-       d="M -0.00009375 -0.0004125 L 51.019438 -0.0004125 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path138"
-       transform="matrix(1,0,0,-1,138.211,323.6734)"
-       d="M -0.0000625 0.001525 L -0.0000625 4.247619 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path140"
-       transform="matrix(1,0,0,-1,85.7662,325.0913)"
-       d="M -0.000575 0.00145625 L 51.026769 0.00145625 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%, 0%, 100%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path142"
-       transform="matrix(1,0,0,-1,357.9341,174.5767)"
-       d="M -0.00050625 -0.001425 C -0.00050625 -1.724081 -1.395037 -3.118612 -3.117694 -3.118612 C -4.84035 -3.118612 -6.234881 -1.724081 -6.234881 -0.001425 C -6.234881 1.721231 -4.84035 3.119669 -3.117694 3.119669 C -1.395037 3.119669 -0.00050625 1.721231 -0.00050625 -0.001425 Z M -0.00050625 -0.001425 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path144"
-       transform="matrix(1,0,0,-1,398.8438,198.731)"
-       d="M -0.00005 0.00053125 C -0.00005 -1.722125 -1.394581 -3.116656 -3.117238 -3.116656 C -4.839894 -3.116656 -6.234425 -1.722125 -6.234425 0.00053125 C -6.234425 1.723188 -4.839894 3.117719 -3.117238 3.117719 C -1.394581 3.117719 -0.00005 1.723188 -0.00005 0.00053125 Z M -0.00005 0.00053125 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path146"
-       transform="matrix(1,0,0,-1,73.1754,97.5513)"
-       d="M 0.00038125 0.00051875 C 0.00038125 -1.722137 -1.39415 -3.116669 -3.116806 -3.116669 C -4.839462 -3.116669 -6.2379 -1.722137 -6.2379 0.00051875 C -6.2379 1.723175 -4.839462 3.117706 -3.116806 3.117706 C -1.39415 3.117706 0.00038125 1.723175 0.00038125 0.00051875 Z M 0.00038125 0.00051875 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path148"
-       transform="matrix(1,0,0,-1,70.0572,147.5825)"
-       d="M 0.00139375 0.00046875 C 1.720144 0.00046875 3.118581 -1.394062 3.118581 -3.116719 C 3.118581 -4.839375 1.720144 -6.237812 0.00139375 -6.237812 C -1.721263 -6.237812 -3.1197 -4.839375 -3.1197 -3.116719 C -3.1197 -1.394062 -1.721263 0.00046875 0.00139375 0.00046875 Z M 0.00139375 0.00046875 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path150"
-       transform="matrix(1,0,0,-1,285.4903,83.8033)"
-       d="M 0.0018875 -0.0013875 C 1.720638 -0.0013875 3.119075 -1.395919 3.119075 -3.118575 C 3.119075 -4.841231 1.720638 -6.235762 0.0018875 -6.235762 C -1.720769 -6.235762 -3.119206 -4.841231 -3.119206 -3.118575 C -3.119206 -1.395919 -1.720769 -0.0013875 0.0018875 -0.0013875 Z M 0.0018875 -0.0013875 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path152"
-       transform="matrix(1,0,0,-1,192.6558,196.481)"
-       d="M 0.00045 0.00053125 C 1.723106 0.00053125 3.117638 -1.397906 3.117638 -3.116656 C 3.117638 -4.839312 1.723106 -6.23775 0.00045 -6.23775 C -1.722206 -6.23775 -3.116737 -4.839312 -3.116737 -3.116656 C -3.116737 -1.397906 -1.722206 0.00053125 0.00045 0.00053125 Z M 0.00045 0.00053125 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path154"
-       transform="matrix(1,0,0,-1,324.4669,218.4497)"
-       d="M 0.00185 0.00048125 C 1.7206 0.00048125 3.119038 -1.39405 3.119038 -3.116706 C 3.119038 -4.839362 1.7206 -6.233894 0.00185 -6.233894 C -1.720806 -6.233894 -3.119244 -4.839362 -3.119244 -3.116706 C -3.119244 -1.39405 -1.720806 0.00048125 0.00185 0.00048125 Z M 0.00185 0.00048125 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path156"
-       transform="matrix(1,0,0,-1,64.3453,461.6421)"
-       d="M -0.00155 0.001475 C -0.00155 -1.721181 1.396888 -3.119619 3.119544 -3.119619 C 4.838294 -3.119619 6.236731 -1.721181 6.236731 0.001475 C 6.236731 1.724131 4.838294 3.118663 3.119544 3.118663 C 1.396888 3.118663 -0.00155 1.724131 -0.00155 0.001475 Z M -0.00155 0.001475 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path158"
-       transform="matrix(1,0,0,-1,23.4356,485.7954)"
-       d="M 0.0019 -0.001475 C 0.0019 -1.724131 1.396431 -3.118662 3.119088 -3.118662 C 4.841744 -3.118662 6.236275 -1.724131 6.236275 -0.001475 C 6.236275 1.721181 4.841744 3.119619 3.119088 3.119619 C 1.396431 3.119619 0.0019 1.721181 0.0019 -0.001475 Z M 0.0019 -0.001475 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path160"
-       transform="matrix(1,0,0,-1,349.1036,384.6157)"
-       d="M 0.00186875 -0.0014875 C 0.00186875 -1.724144 1.3964 -3.118675 3.119056 -3.118675 C 4.841712 -3.118675 6.236244 -1.724144 6.236244 -0.0014875 C 6.236244 1.721169 4.841712 3.119606 3.119056 3.119606 C 1.3964 3.119606 0.00186875 1.721169 0.00186875 -0.0014875 Z M 0.00186875 -0.0014875 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path162"
-       transform="matrix(1,0,0,-1,352.2217,434.648)"
-       d="M 0.00095625 -0.0004375 C -1.7217 -0.0004375 -3.116231 -1.394969 -3.116231 -3.117625 C -3.116231 -4.840281 -1.7217 -6.234812 0.00095625 -6.234812 C 1.723613 -6.234812 3.118144 -4.840281 3.118144 -3.117625 C 3.118144 -1.394969 1.723613 -0.0004375 0.00095625 -0.0004375 Z M 0.00095625 -0.0004375 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path164"
-       transform="matrix(1,0,0,-1,136.7886,370.8687)"
-       d="M 0.0004625 0.0015125 C -1.722194 0.0015125 -3.116725 -1.396925 -3.116725 -3.119581 C -3.116725 -4.838331 -1.722194 -6.236769 0.0004625 -6.236769 C 1.723119 -6.236769 3.11765 -4.838331 3.11765 -3.119581 C 3.11765 -1.396925 1.723119 0.0015125 0.0004625 0.0015125 Z M 0.0004625 0.0015125 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path166"
-       transform="matrix(1,0,0,-1,229.6231,483.5454)"
-       d="M 0.0019 -0.001475 C -1.720756 -0.001475 -3.119194 -1.396006 -3.119194 -3.118662 C -3.119194 -4.841319 -1.720756 -6.23585 0.0019 -6.23585 C 1.72065 -6.23585 3.119088 -4.841319 3.119088 -3.118662 C 3.119088 -1.396006 1.72065 -0.001475 0.0019 -0.001475 Z M 0.0019 -0.001475 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path168"
-       transform="matrix(1,0,0,-1,97.8126,505.5142)"
-       d="M -0.0001 -0.001425 C -1.722756 -0.001425 -3.117288 -1.395956 -3.117288 -3.118612 C -3.117288 -4.841269 -1.722756 -6.2358 -0.0001 -6.2358 C 1.722556 -6.2358 3.117087 -4.841269 3.117087 -3.118612 C 3.117087 -1.395956 1.722556 -0.001425 -0.0001 -0.001425 Z M -0.0001 -0.001425 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path170"
-       transform="matrix(1,0,0,-1,0,595.276)"
-       d="M 65.121094 506.865844 L 21.183594 506.865844 L 21.183594 543.151 L 65.121094 543.151 Z M 65.121094 506.865844 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path172"
-       transform="matrix(1,0,0,-1,0,595.276)"
-       d="M 65.121094 453.010375 L 21.183594 453.010375 L 21.183594 489.291625 L 65.121094 489.291625 Z M 65.121094 453.010375 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path174"
-       transform="matrix(1,0,0,-1,0,595.276)"
-       d="M 65.121094 399.151 L 21.183594 399.151 L 21.183594 435.43225 L 65.121094 435.43225 Z M 65.121094 399.151 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path176"
-       transform="matrix(1,0,0,-1,0,595.276)"
-       d="M 118.976562 506.86975 L 75.039062 506.86975 L 75.039062 543.151 L 118.976562 543.151 Z M 118.976562 506.86975 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path178"
-       transform="matrix(1,0,0,-1,0,595.276)"
-       d="M 118.976562 453.010375 L 75.039062 453.010375 L 75.039062 489.295531 L 118.976562 489.295531 Z M 118.976562 453.010375 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path180"
-       transform="matrix(1,0,0,-1,0,595.276)"
-       d="M 118.976562 399.151 L 75.039062 399.151 L 75.039062 435.436156 L 118.976562 435.436156 Z M 118.976562 399.151 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path182"
-       transform="matrix(1,0,0,-1,0,595.276)"
-       d="M 172.835938 520.318969 L 128.898438 520.318969 L 128.898438 556.600219 L 172.835938 556.600219 Z M 172.835938 520.318969 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path184"
-       transform="matrix(1,0,0,-1,0,595.276)"
-       d="M 172.835938 466.459594 L 128.898438 466.459594 L 128.898438 502.74475 L 172.835938 502.74475 Z M 172.835938 466.459594 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path186"
-       transform="matrix(1,0,0,-1,0,595.276)"
-       d="M 172.835938 412.604125 L 128.898438 412.604125 L 128.898438 448.885375 L 172.835938 448.885375 Z M 172.835938 412.604125 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path188"
-       transform="matrix(1,0,0,-1,0,595.276)"
-       d="M 226.695312 527.061156 L 182.761719 527.061156 L 182.761719 563.346313 L 226.695312 563.346313 Z M 226.695312 527.061156 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path190"
-       transform="matrix(1,0,0,-1,0,595.276)"
-       d="M 226.695312 473.205688 L 182.761719 473.205688 L 182.761719 509.486938 L 226.695312 509.486938 Z M 226.695312 473.205688 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path192"
-       transform="matrix(1,0,0,-1,0,595.276)"
-       d="M 226.695312 419.346313 L 182.761719 419.346313 L 182.761719 455.627563 L 226.695312 455.627563 Z M 226.695312 419.346313 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path194"
-       transform="matrix(1,0,0,-1,0,595.276)"
-       d="M 280.558594 520.330688 L 236.621094 520.330688 L 236.621094 556.615844 L 280.558594 556.615844 Z M 280.558594 520.330688 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path196"
-       transform="matrix(1,0,0,-1,0,595.276)"
-       d="M 280.558594 466.471313 L 236.621094 466.471313 L 236.621094 502.756469 L 280.558594 502.756469 Z M 280.558594 466.471313 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path198"
-       transform="matrix(1,0,0,-1,0,595.276)"
-       d="M 280.558594 412.615844 L 236.621094 412.615844 L 236.621094 448.897094 L 280.558594 448.897094 Z M 280.558594 412.615844 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path200"
-       transform="matrix(1,0,0,-1,0,595.276)"
-       d="M 334.421875 513.572875 L 290.484375 513.572875 L 290.484375 549.854125 L 334.421875 549.854125 Z M 334.421875 513.572875 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path202"
-       transform="matrix(1,0,0,-1,0,595.276)"
-       d="M 334.421875 459.7135 L 290.484375 459.7135 L 290.484375 495.99475 L 334.421875 495.99475 Z M 334.421875 459.7135 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path204"
-       transform="matrix(1,0,0,-1,0,595.276)"
-       d="M 334.421875 405.854125 L 290.484375 405.854125 L 290.484375 442.139281 L 334.421875 442.139281 Z M 334.421875 405.854125 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path206"
-       transform="matrix(1,0,0,-1,0,595.276)"
-       d="M 253.273438 356.893188 L 209.335938 356.893188 L 209.335938 393.174438 L 253.273438 393.174438 Z M 253.273438 356.893188 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path208"
-       transform="matrix(1,0,0,-1,307.6597,251.1343)"
-       d="M 0.00045625 0.0014875 L -42.44095 11.372581 L -33.050325 46.419456 L 9.391081 35.048363 Z M 0.00045625 0.0014875 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path210"
-       transform="matrix(1,0,0,-1,380.9244,228.5728)"
-       d="M 0.00138125 -0.00141875 L -21.967369 -38.0522 L -53.389244 -19.907669 L -31.420494 18.143113 Z M 0.00138125 -0.00141875 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path212"
-       transform="matrix(1,0,0,-1,0,595.276)"
-       d="M 357.15625 219.803344 L 401.09375 219.803344 L 401.09375 256.084594 L 357.15625 256.084594 Z M 357.15625 219.803344 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path214"
-       transform="matrix(1,0,0,-1,0,595.276)"
-       d="M 357.15625 165.943969 L 401.09375 165.943969 L 401.09375 202.225219 L 357.15625 202.225219 Z M 357.15625 165.943969 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path216"
-       transform="matrix(1,0,0,-1,0,595.276)"
-       d="M 357.15625 112.084594 L 401.09375 112.084594 L 401.09375 148.36975 L 357.15625 148.36975 Z M 357.15625 112.084594 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path218"
-       transform="matrix(1,0,0,-1,0,595.276)"
-       d="M 303.304688 219.803344 L 347.242188 219.803344 L 347.242188 256.0885 L 303.304688 256.0885 Z M 303.304688 219.803344 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path220"
-       transform="matrix(1,0,0,-1,0,595.276)"
-       d="M 303.304688 165.947875 L 347.242188 165.947875 L 347.242188 202.229125 L 303.304688 202.229125 Z M 303.304688 165.947875 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path222"
-       transform="matrix(1,0,0,-1,0,595.276)"
-       d="M 303.304688 112.0885 L 347.242188 112.0885 L 347.242188 148.36975 L 303.304688 148.36975 Z M 303.304688 112.0885 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path224"
-       transform="matrix(1,0,0,-1,0,595.276)"
-       d="M 249.445312 233.252563 L 293.382812 233.252563 L 293.382812 269.537719 L 249.445312 269.537719 Z M 249.445312 233.252563 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path226"
-       transform="matrix(1,0,0,-1,0,595.276)"
-       d="M 249.445312 179.397094 L 293.382812 179.397094 L 293.382812 215.678344 L 249.445312 215.678344 Z M 249.445312 179.397094 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path228"
-       transform="matrix(1,0,0,-1,0,595.276)"
-       d="M 249.445312 125.537719 L 293.382812 125.537719 L 293.382812 161.822875 L 249.445312 161.822875 Z M 249.445312 125.537719 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path230"
-       transform="matrix(1,0,0,-1,0,595.276)"
-       d="M 195.582031 239.998656 L 239.519531 239.998656 L 239.519531 276.279906 L 195.582031 276.279906 Z M 195.582031 239.998656 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path232"
-       transform="matrix(1,0,0,-1,0,595.276)"
-       d="M 195.582031 186.139281 L 239.519531 186.139281 L 239.519531 222.424438 L 195.582031 222.424438 Z M 195.582031 186.139281 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path234"
-       transform="matrix(1,0,0,-1,0,595.276)"
-       d="M 195.582031 132.279906 L 239.519531 132.279906 L 239.519531 168.565063 L 195.582031 168.565063 Z M 195.582031 132.279906 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path236"
-       transform="matrix(1,0,0,-1,0,595.276)"
-       d="M 141.71875 233.268188 L 185.65625 233.268188 L 185.65625 269.549438 L 141.71875 269.549438 Z M 141.71875 233.268188 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path238"
-       transform="matrix(1,0,0,-1,0,595.276)"
-       d="M 141.71875 179.408813 L 185.65625 179.408813 L 185.65625 215.690063 L 141.71875 215.690063 Z M 141.71875 179.408813 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path240"
-       transform="matrix(1,0,0,-1,0,595.276)"
-       d="M 141.71875 125.549438 L 185.65625 125.549438 L 185.65625 161.834594 L 141.71875 161.834594 Z M 141.71875 125.549438 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path242"
-       transform="matrix(1,0,0,-1,0,595.276)"
-       d="M 87.855469 226.506469 L 131.792969 226.506469 L 131.792969 262.791625 L 87.855469 262.791625 Z M 87.855469 226.506469 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path244"
-       transform="matrix(1,0,0,-1,0,595.276)"
-       d="M 87.855469 172.647094 L 131.792969 172.647094 L 131.792969 208.93225 L 87.855469 208.93225 Z M 87.855469 172.647094 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path246"
-       transform="matrix(1,0,0,-1,0,595.276)"
-       d="M 87.855469 118.791625 L 131.792969 118.791625 L 131.792969 155.072875 L 87.855469 155.072875 Z M 87.855469 118.791625 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path248"
-       transform="matrix(1,0,0,-1,0,595.276)"
-       d="M 169.007812 69.826781 L 212.945312 69.826781 L 212.945312 106.111938 L 169.007812 106.111938 Z M 169.007812 69.826781 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path250"
-       transform="matrix(1,0,0,-1,114.6192,538.1997)"
-       d="M 0.00189375 0.00048125 L 42.439394 11.371575 L 33.048769 46.41845 L -9.392638 35.047356 Z M 0.00189375 0.00048125 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       id="path252"
-       transform="matrix(1,0,0,-1,41.355,515.6372)"
-       d="M 0.00046875 0.00048125 L 21.969219 -38.0503 L 53.391094 -19.909675 L 31.422344 18.141106 Z M 0.00046875 0.00048125 "
-       style="fill:none;stroke-width:0.99974998;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%, 0%, 0%);stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
+     id="g13931">
+    <g
+       id="g13861">
+      <g
+         id="g13826">
+        <path
+           id="path2"
+           d="M 403.20312,41.394531 V 207.9375 c 0,1.08984 -1.17968,1.77344 -2.125,1.22656 l -53.05859,-30.62109 c -0.44141,-0.25391 -0.71094,-0.72266 -0.71094,-1.22656 V 41.398437 c 0,-0.78125 0.63672,-1.414062 1.41797,-1.417968 l 53.0625,-0.0039 c 0.78125,0 1.41406,0.632813 1.41406,1.417969 z"
+           style="fill:none;stroke:#0000ff;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           sodipodi:nodetypes="csccssccsc" />
+        <path
+           id="path142"
+           d="m 357.93359,174.57812 c 0,1.72266 -1.39453,3.11719 -3.11718,3.11719 -1.72266,0 -3.11719,-1.39453 -3.11719,-3.11719 0,-1.72265 1.39453,-3.12109 3.11719,-3.12109 1.72265,0 3.11718,1.39844 3.11718,3.12109 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path144"
+           d="m 398.84375,198.73047 c 0,1.72265 -1.39453,3.11719 -3.11719,3.11719 -1.72265,0 -3.11719,-1.39454 -3.11719,-3.11719 0,-1.72266 1.39454,-3.11719 3.11719,-3.11719 1.72266,0 3.11719,1.39453 3.11719,3.11719 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
+      <g
+         id="g13821">
+        <g
+           id="g4026">
+          <path
+             id="path68"
+             style="fill:none;stroke:#0000ff;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 337.92778,39.447265 c 0.002,-0.779296 -0.63086,-1.416015 -1.41409,-1.417968 h -51.02541 c -0.78125,0.002 -1.41406,-0.63086 -1.41602,-1.416016 v -4.251953 c 0.002,-0.779297 -0.63476,-1.416016 -1.41991,-1.417969 h -51.01954 c -0.78515,0.002 -1.41797,-0.630859 -1.41992,-1.417969 v -3.542968 c 0.002,-0.779297 -0.63086,-1.416016 -1.41797,-1.417969 h -48.1875 c -0.7832,0.002 -1.41601,0.638672 -1.41797,1.417969 v 3.542969 c 0.002,0.787109 -0.63476,1.419921 -1.41797,1.417968 H 126.75 c -0.78125,0.002 -1.41797,0.638672 -1.41797,1.417969 v 10.628906 c 0,0.78711 -0.63281,1.419922 -1.41992,1.417969 H 19.033203 c -0.783203,0.002 -1.416016,0.638672 -1.417969,1.417969 V 202.43945 c 0.002,0.78711 0.634766,1.41992 1.416014,1.41797 H 174.9375 c 0.37891,0.002 0.73828,0.15039 1.00195,0.41211 l 29.88677,40.98247 c 0.26763,0.26762 0.627,0.41996 1.002,0.41796 l 103.94727,13.51949 c 0.63086,0.0644 1.25195,0.18945 1.85742,0.36718 l 40.51562,23.41601 c 1.80079,1.21876 4.2461,0.74219 5.46094,-1.05859 0,-0.004 0.004,-0.008 0.004,-0.0137 l 35.01944,-60.82228 c 1.21094,-1.79687 0.73828,-4.24218 -1.0625,-5.45312 l -0.0176,-0.0156 -53.63282,-30.95313 c -0.60351,-0.44141 -0.97464,-1.13672 -0.99819,-1.88672 z"
+             sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccccc" />
+        </g>
+        <path
+           id="path146"
+           d="m 73.175781,97.550781 c 0,1.722656 -1.394531,3.117189 -3.117187,3.117189 -1.722656,0 -3.121094,-1.394533 -3.121094,-3.117189 0,-1.722656 1.398438,-3.117187 3.121094,-3.117187 1.722656,0 3.117187,1.394531 3.117187,3.117187 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path148"
+           d="m 70.058594,147.58203 c 1.71875,0 3.117187,1.39453 3.117187,3.11719 0,1.72265 -1.398437,3.12109 -3.117187,3.12109 -1.722657,0 -3.121094,-1.39844 -3.121094,-3.12109 0,-1.72266 1.398437,-3.11719 3.121094,-3.11719 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path150"
+           d="m 285.49219,83.804687 c 1.71875,0 3.11718,1.394532 3.11718,3.117188 0,1.722656 -1.39843,3.117187 -3.11718,3.117187 -1.72266,0 -3.1211,-1.394531 -3.1211,-3.117187 0,-1.722656 1.39844,-3.117188 3.1211,-3.117188 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path152"
+           d="m 192.65625,196.48047 c 1.72266,0 3.11719,1.39844 3.11719,3.11719 0,1.72265 -1.39453,3.12109 -3.11719,3.12109 -1.72266,0 -3.11719,-1.39844 -3.11719,-3.12109 0,-1.71875 1.39453,-3.11719 3.11719,-3.11719 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path154"
+           d="m 324.46875,218.44922 c 1.71875,0 3.11719,1.39453 3.11719,3.11719 0,1.72265 -1.39844,3.11718 -3.11719,3.11718 -1.72266,0 -3.12109,-1.39453 -3.12109,-3.11718 0,-1.72266 1.39843,-3.11719 3.12109,-3.11719 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path170"
+           d="m 65.121094,88.41016 h -43.9375 V 52.125 h 43.9375 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path172"
+           d="m 65.121094,142.26563 h -43.9375 v -36.28125 h 43.9375 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path174"
+           d="m 65.121094,196.125 h -43.9375 v -36.28125 h 43.9375 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path176"
+           d="M 118.97656,88.40625 H 75.039062 V 52.125 h 43.937498 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path178"
+           d="M 118.97656,142.26563 H 75.039062 v -36.28516 h 43.937498 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path180"
+           d="M 118.97656,196.125 H 75.039062 v -36.28516 h 43.937498 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path182"
+           d="m 172.83594,74.95703 h -43.9375 V 38.67578 h 43.9375 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path184"
+           d="m 172.83594,128.81641 h -43.9375 V 92.53125 h 43.9375 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path186"
+           d="m 172.83594,182.67188 h -43.9375 v -36.28125 h 43.9375 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path188"
+           d="M 226.69531,68.21484 H 182.76172 V 31.92969 h 43.93359 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path190"
+           d="M 226.69531,122.07031 H 182.76172 V 85.78906 h 43.93359 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path192"
+           d="m 226.69531,175.92969 h -43.93359 v -36.28125 h 43.93359 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path194"
+           d="m 280.55859,74.94531 h -43.9375 V 38.66016 h 43.9375 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path196"
+           d="m 280.55859,128.80469 h -43.9375 V 92.51953 h 43.9375 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path198"
+           d="m 280.55859,182.66016 h -43.9375 v -36.28125 h 43.9375 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path200"
+           d="m 334.42187,81.70313 h -43.9375 V 45.42188 h 43.9375 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path202"
+           d="m 334.42187,135.5625 h -43.9375 V 99.28125 h 43.9375 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path204"
+           d="m 334.42187,189.42188 h -43.9375 v -36.28516 h 43.9375 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path206"
+           d="m 253.27344,238.38281 h -43.9375 v -36.28125 h 43.9375 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path208"
+           d="m 307.66016,251.13281 -42.44141,-11.37109 9.39062,-35.04688 42.44141,11.3711 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path210"
+           d="m 380.92578,228.57422 -21.96875,38.05078 -31.42187,-18.14453 21.96875,-38.05078 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
+    </g>
+    <g
+       id="g13760">
+      <g
+         id="g13725">
+        <path
+           id="path72"
+           d="m 19.074219,328.45703 v 166.54688 c 0,1.08984 1.179687,1.77343 2.125,1.22656 l 53.0625,-30.6211 c 0.4375,-0.2539 0.707031,-0.72265 0.707031,-1.23046 V 328.46484 c 0,-0.78125 -0.632813,-1.41797 -1.414063,-1.41797 l -53.0625,-0.008 c -0.78125,0 -1.417968,0.63672 -1.417968,1.41797 z m 0,0"
+           style="fill:none;stroke:#0000ff;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path156"
+           d="m 64.34375,461.64062 c 0,1.72266 1.398438,3.1211 3.121094,3.1211 1.71875,0 3.117187,-1.39844 3.117187,-3.1211 0,-1.72265 -1.398437,-3.11718 -3.117187,-3.11718 -1.722656,0 -3.121094,1.39453 -3.121094,3.11718 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path158"
+           d="m 23.4375,485.79687 c 0,1.72266 1.394531,3.11719 3.117188,3.11719 1.722656,0 3.117187,-1.39453 3.117187,-3.11719 0,-1.72265 -1.394531,-3.12109 -3.117187,-3.12109 -1.722657,0 -3.117188,1.39844 -3.117188,3.12109 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
+      <g
+         id="g13720">
+        <g
+           id="g9145">
+          <path
+             id="path140"
+             style="fill:none;stroke:#0000ff;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 403.24804,490.92383 h -155.9082 c -0.375,0.002 -0.73437,0.15039 -1,0.4121 l -29.88672,40.98248 c -0.26562,0.26763 -0.625,0.41606 -1.0019,0.41406 l -103.94531,13.52339 c -0.63091,0.0644 -1.252,0.18555 -1.85742,0.36718 l -40.51758,23.41603 c -1.802785,1.21484 -4.248097,0.74218 -5.459035,-1.0586 -0.0039,-0.004 -0.0078,-0.0117 -0.0059,-0.0176 L 28.648437,508.14453 c -1.214843,-1.80078 -0.6702,-4.14692 1.0625,-5.45703 l 0.01563,-0.0118 53.632812,-30.95694 c 0.605469,-0.4375 0.972654,-1.13281 0.999994,-1.88476 l -0.0078,-143.32032 c -0.0039,-0.7832 0.628907,-1.41601 1.414063,-1.41992 h 51.025394 c 0.77929,0.004 1.41601,-0.62891 1.41797,-1.41797 v -4.24805 c -0.002,-0.7832 0.63085,-1.41601 1.41796,-1.41797 h 51.02149 c 0.78125,0.002 1.41797,-0.63476 1.41797,-1.41797 v -3.54297 c 0,-0.77929 0.63281,-1.41601 1.41601,-1.41796 h 48.1914 c 0.7793,0.002 1.41602,0.63867 1.41797,1.41796 v 3.54297 c -0.002,0.78712 0.63087,1.41993 1.41797,1.41797 h 51.02149 c 0.78125,0.002 1.41406,0.63477 1.41602,1.41797 v 10.62695 c -0.002,0.78516 0.63476,1.42188 1.41796,1.41993 h 104.88281 c 0.7793,0.002 1.41602,0.63476 1.41798,1.41796 l 2e-5,156.61328 c -0.002,0.7832 -0.63871,1.41992 -1.41801,1.41797 z"
+             sodipodi:nodetypes="cccccccccccsccccccccccccccccccccccccc" />
+        </g>
+        <path
+           id="path160"
+           d="m 349.10547,384.61719 c 0,1.72265 1.39453,3.11718 3.11719,3.11718 1.72265,0 3.11718,-1.39453 3.11718,-3.11718 0,-1.72266 -1.39453,-3.1211 -3.11718,-3.1211 -1.72266,0 -3.11719,1.39844 -3.11719,3.1211 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path162"
+           d="m 352.22266,434.64844 c -1.72266,0 -3.11719,1.39453 -3.11719,3.11718 0,1.72266 1.39453,3.11719 3.11719,3.11719 1.72265,0 3.11718,-1.39453 3.11718,-3.11719 0,-1.72265 -1.39453,-3.11718 -3.11718,-3.11718 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path164"
+           d="m 136.78906,370.86719 c -1.72265,0 -3.11719,1.39843 -3.11719,3.12109 0,1.71875 1.39454,3.11719 3.11719,3.11719 1.72266,0 3.11719,-1.39844 3.11719,-3.11719 0,-1.72266 -1.39453,-3.12109 -3.11719,-3.12109 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path166"
+           d="m 229.625,483.54687 c -1.72266,0 -3.12109,1.39454 -3.12109,3.11719 0,1.72266 1.39843,3.11719 3.12109,3.11719 1.71875,0 3.11719,-1.39453 3.11719,-3.11719 0,-1.72265 -1.39844,-3.11719 -3.11719,-3.11719 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path168"
+           d="m 97.8125,505.51562 c -1.722656,0 -3.117188,1.39454 -3.117188,3.11719 0,1.72266 1.394532,3.11719 3.117188,3.11719 1.722656,0 3.11719,-1.39453 3.11719,-3.11719 0,-1.72265 -1.394534,-3.11719 -3.11719,-3.11719 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path212"
+           d="m 357.15625,375.47266 h 43.9375 v -36.28125 h -43.9375 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path214"
+           d="m 357.15625,429.33203 h 43.9375 v -36.28125 h -43.9375 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path216"
+           d="m 357.15625,483.19141 h 43.9375 v -36.28516 h -43.9375 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path218"
+           d="m 303.30469,375.47266 h 43.9375 V 339.1875 h -43.9375 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path220"
+           d="m 303.30469,429.32813 h 43.9375 v -36.28125 h -43.9375 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path222"
+           d="m 303.30469,483.1875 h 43.9375 v -36.28125 h -43.9375 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path224"
+           d="m 249.44531,362.02344 h 43.9375 v -36.28516 h -43.9375 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path226"
+           d="m 249.44531,415.87891 h 43.9375 v -36.28125 h -43.9375 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path228"
+           d="m 249.44531,469.73828 h 43.9375 v -36.28515 h -43.9375 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path230"
+           d="m 195.58203,355.27734 h 43.9375 v -36.28125 h -43.9375 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path232"
+           d="m 195.58203,409.13672 h 43.9375 v -36.28516 h -43.9375 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path234"
+           d="m 195.58203,462.99609 h 43.9375 v -36.28515 h -43.9375 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path236"
+           d="m 141.71875,362.00781 h 43.9375 v -36.28125 h -43.9375 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path238"
+           d="m 141.71875,415.86719 h 43.9375 v -36.28125 h -43.9375 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path240"
+           d="m 141.71875,469.72656 h 43.9375 v -36.28515 h -43.9375 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path242"
+           d="M 87.855469,368.76953 H 131.79297 V 332.48438 H 87.855469 Z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path244"
+           d="M 87.855469,422.62891 H 131.79297 V 386.34375 H 87.855469 Z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path246"
+           d="M 87.855469,476.48438 H 131.79297 V 440.20313 H 87.855469 Z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path248"
+           d="m 169.00781,525.44922 h 43.9375 v -36.28516 h -43.9375 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path250"
+           d="m 114.62109,538.19922 42.4375,-11.3711 -9.39062,-35.04687 -42.44141,11.37109 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path252"
+           d="m 41.355469,515.63672 21.96875,38.05078 31.421875,-18.14063 -21.96875,-38.05078 z m 0,0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.99975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
+    </g>
   </g>
 </svg>


### PR DESCRIPTION
### Problem
While trying to create a 3D extrusion of the top plate (alps) I noticed that the paths of the outline were not connected. FreeCad constantly failed to create the 3D shape despite many attempts to correct it.

### Change
Using Inkscape I've manually joined the nodes of the paths that form the outside contour of the left and right plates. The geometry was unchanged. Just hoping to save others some time.