### PR TITLE
Update .gitignore for kicad6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ gerber/
 # Autorouter files (exported from Pcbnew)
 *.dsn
 *.ses
+
+# Backup files (exported from Pcbnew)
+*-backups/


### PR DESCRIPTION
KiCad 6 generates backup files at `*-backups/`, so ignore for Git.