### PR TITLE
Adds REUSE/SPDX license info

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 foostan <ks@fstn.jp>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 # These are supported funding model platforms
 
 github: [foostan]

--- a/.github/workflows/release-corne-cherry.yml
+++ b/.github/workflows/release-corne-cherry.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 foostan <ks@fstn.jp>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 name: Release Corne Cherry
 
 on:

--- a/.github/workflows/release-corne-chocolate.yml
+++ b/.github/workflows/release-corne-chocolate.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 foostan <ks@fstn.jp>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 name: Release Corne Chocolate
 
 on:

--- a/.github/workflows/release-corne-classic.yml
+++ b/.github/workflows/release-corne-classic.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 foostan <ks@fstn.jp>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 name: Release Corne Classic
 
 on:

--- a/.github/workflows/release-corne-light.yml
+++ b/.github/workflows/release-corne-light.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 foostan <ks@fstn.jp>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 name: Release Corne Light
 
 on:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
+# SPDX-FileCopyrightText: 2020 foostan <ks@fstn.jp>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 # OSX thumbnails cache file
 .DS_Store
-
 
 # For PCBs designed using KiCad: http://www.kicad-pcb.org/
 # Format documentation: http://kicad-pcb.org/help/file-formats/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 foostan <ks@fstn.jp>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 [submodule "corne-cherry/pcb/kbd"]
 	path = corne-cherry/pcb/kbd
 	url = https://github.com/foostan/kbd

--- a/.kiplot.yml
+++ b/.kiplot.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 foostan <ks@fstn.jp>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 kiplot:
   version: 1
 

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,0 +1,9 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: Corne Keyboard (crkbd)
+Upstream-Contact: foostan <ks@fstn.jp>
+Source: https://gitlab.com/foostan/crkbd
+
+Files: *.ai *.dcm *.drl *.dxf **/fp-lib-table *.gbl *.gbo *.gbr *.gbs *.gm1 *.gtl *.gto *.gts *.jpg *.kicad_pcb *.lib *.net *.pro *.ps *.sch *.svg **/sym-lib-table *.xml
+Copyright: foostan <ks@fstn.jp>
+License: MIT
+

--- a/LICENSES/CC0-1.0.txt
+++ b/LICENSES/CC0-1.0.txt
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 foostan <ks@fstn.jp>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 .PHONY: git-submodule
 git-submodule:
 	git submodule sync --recursive

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2021 foostan <ks@fstn.jp>
+
+SPDX-License-Identifier: MIT
+-->
+
 # Corne keyboard
 
 The Corne keyboard is a split keyboard with 3x6 column staggered keys

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ SPDX-License-Identifier: MIT
 
 # Corne keyboard
 
+[![REUSE status](
+  https://api.reuse.software/badge/github.com/foostan/crkbd)](
+  https://api.reuse.software/info/github.com/foostan/crkbd)
+
 The Corne keyboard is a split keyboard with 3x6 column staggered keys
 and 3 thumb keys, based on [Helix](https://github.com/MakotoKurauchi/helix).
 Crkbd stands for Corne Keyboard.

--- a/corne-cherry/doc/buildguide_en.md
+++ b/corne-cherry/doc/buildguide_en.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2021 foostan <ks@fstn.jp>
+
+SPDX-License-Identifier: MIT
+-->
+
 # Build Guide
 
 This is the Corne Cherry build guide.

--- a/corne-cherry/doc/buildguide_jp.md
+++ b/corne-cherry/doc/buildguide_jp.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2021 foostan <ks@fstn.jp>
+
+SPDX-License-Identifier: MIT
+-->
+
 # Build Guide
 
 こちらは Corne Cherry のビルドガイドになります。

--- a/corne-cherry/doc/v2/buildguide_en.md
+++ b/corne-cherry/doc/v2/buildguide_en.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2021 foostan <ks@fstn.jp>
+
+SPDX-License-Identifier: MIT
+-->
+
 # Build Guide
 
 This is the build guide for Corne Cherry v2.

--- a/corne-cherry/doc/v2/buildguide_jp.md
+++ b/corne-cherry/doc/v2/buildguide_jp.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2021 foostan <ks@fstn.jp>
+
+SPDX-License-Identifier: MIT
+-->
+
 # Build Guide
 
 こちらは Corne Cherry v2 のビルドガイドになります。

--- a/corne-cherry/doc/v2/buildguide_tilting_tenting_plate_en.md
+++ b/corne-cherry/doc/v2/buildguide_tilting_tenting_plate_en.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2021 foostan <ks@fstn.jp>
+
+SPDX-License-Identifier: MIT
+-->
+
 # Build Guide Tilting / Tenting plate
 
 ## Parts

--- a/corne-cherry/doc/v2/buildguide_tilting_tenting_plate_jp.md
+++ b/corne-cherry/doc/v2/buildguide_tilting_tenting_plate_jp.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2021 foostan <ks@fstn.jp>
+
+SPDX-License-Identifier: MIT
+-->
+
 # Build Guide Tilting/Tenting plate
 
 ## 部品

--- a/corne-cherry/doc/v3/buildguide_en.md
+++ b/corne-cherry/doc/v3/buildguide_en.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2021 foostan <ks@fstn.jp>
+
+SPDX-License-Identifier: MIT
+-->
+
 # Build Guide
 
 This is the build guide for Corne Cherry v3.

--- a/corne-cherry/doc/v3/buildguide_jp.md
+++ b/corne-cherry/doc/v3/buildguide_jp.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2021 foostan <ks@fstn.jp>
+
+SPDX-License-Identifier: MIT
+-->
+
 # Build Guide
 
 こちらは Corne Cherry v3 のビルドガイドになります。

--- a/corne-chocolate/doc/buildguide_en.md
+++ b/corne-chocolate/doc/buildguide_en.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2021 foostan <ks@fstn.jp>
+
+SPDX-License-Identifier: MIT
+-->
+
 # Build Guide
 
 This is the build guide for Corne Chocolate.

--- a/corne-chocolate/doc/buildguide_jp.md
+++ b/corne-chocolate/doc/buildguide_jp.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2021 foostan <ks@fstn.jp>
+
+SPDX-License-Identifier: MIT
+-->
+
 # Build Guide
 
 こちらは Corne Chocolate のビルドガイドになります。

--- a/corne-classic/doc/buildguide_en.md
+++ b/corne-classic/doc/buildguide_en.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2021 foostan <ks@fstn.jp>
+
+SPDX-License-Identifier: MIT
+-->
+
 # Build Guide
 
 ## Parts

--- a/corne-classic/doc/buildguide_jp.md
+++ b/corne-classic/doc/buildguide_jp.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2021 foostan <ks@fstn.jp>
+
+SPDX-License-Identifier: MIT
+-->
+
 # Build Guide
 
 ## 部品

--- a/corne-light/doc/buildguide_en.md
+++ b/corne-light/doc/buildguide_en.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2021 foostan <ks@fstn.jp>
+
+SPDX-License-Identifier: MIT
+-->
+
 # Build Guide
 
 This is the Corne Light build guide.

--- a/corne-light/doc/buildguide_jp.md
+++ b/corne-light/doc/buildguide_jp.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2021 foostan <ks@fstn.jp>
+
+SPDX-License-Identifier: MIT
+-->
+
 # Build Guide
 
 こちらは Corne Light のビルドガイドになります。

--- a/corne-light/doc/v1/buildguide_en.md
+++ b/corne-light/doc/v1/buildguide_en.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2021 foostan <ks@fstn.jp>
+
+SPDX-License-Identifier: MIT
+-->
+
 # Build Guide
 
 This is the Corne Light v1 build guide.

--- a/corne-light/doc/v1/buildguide_jp.md
+++ b/corne-light/doc/v1/buildguide_jp.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2021 foostan <ks@fstn.jp>
+
+SPDX-License-Identifier: MIT
+-->
+
 # Build Guide
 
 こちらは Corne Light のビルドガイドになります。

--- a/corne-light/doc/v2/buildguide_low_edition_en.md
+++ b/corne-light/doc/v2/buildguide_low_edition_en.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2021 foostan <ks@fstn.jp>
+
+SPDX-License-Identifier: MIT
+-->
+
 # Build Guide
 
 This is the build guide for Corne Light v2 Low edition.

--- a/corne-light/doc/v2/buildguide_low_edition_jp.md
+++ b/corne-light/doc/v2/buildguide_low_edition_jp.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2021 foostan <ks@fstn.jp>
+
+SPDX-License-Identifier: MIT
+-->
+
 # Build Guide
 
 こちらは Corne Light v2 Low edition のビルドガイドになります。

--- a/doc/firmware_en.md
+++ b/doc/firmware_en.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2021 foostan <ks@fstn.jp>
+
+SPDX-License-Identifier: MIT
+-->
+
 # Firmware
 
 ## Flash the firmware

--- a/doc/firmware_jp.md
+++ b/doc/firmware_jp.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2021 foostan <ks@fstn.jp>
+
+SPDX-License-Identifier: MIT
+-->
+
 # ファームウェア
 
 ## ファームウェアの書き込み


### PR DESCRIPTION
[REUSE](https://reuse.software/) and the associated [CLI tool](https://github.com/fsfe/reuse-tool) (both from FSF),
allow to properly specify licensing in a thorough, machine-readable way, on a per-file basis.
These changes make crkbd use this way of specifying licenses.

NOTE: For the badge in the README to work, after accepting, you'd still have to register the project URL with REUSE , to get automatic evaluation of the current state reflected in the badge icon. You do that just by clicking on the badge. I would also do it, if you do not want. it is like creating an account somewhere, with email verification.