### PR TITLE
Generate Gerbers for 3x5 PCB plates

### DIFF
--- a/.github/workflows/release-corne-cherry.yml
+++ b/.github/workflows/release-corne-cherry.yml
@@ -12,32 +12,32 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Export corne-cherry gerber
-      uses: nerdyscout/kicad-exports@v2.2
+      uses: nerdyscout/kicad-exports@v2.3
       with:
         config: .kiplot.yml
         dir: corne-cherry/gerber
         board: corne-cherry/pcb/corne-cherry.kicad_pcb
         schema: corne-cherry/pcb/corne-cherry.kicad_sch
     - name: Export top plate gerber
-      uses: nerdyscout/kicad-exports@v2.2
+      uses: nerdyscout/kicad-exports@v2.3
       with:
         config: .kiplot.yml
         dir: plates/pcb/top/gerber
         board: plates/pcb/top/corne-top-plate.kicad_pcb
     - name: Export bottom plate gerber
-      uses: nerdyscout/kicad-exports@v2.2
+      uses: nerdyscout/kicad-exports@v2.3
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom/gerber
         board: plates/pcb/bottom/corne-bottom-plate.kicad_pcb
     - name: Export top plate mini gerber
-      uses: nerdyscout/kicad-exports@v2.2
+      uses: nerdyscout/kicad-exports@v2.3
       with:
         config: .kiplot.yml
         dir: plates/pcb/top-mini/gerber
         board: plates/pcb/top-mini/corne-top-plate.kicad_pcb
     - name: Export bottom plate mini gerber
-      uses: nerdyscout/kicad-exports@v2.2
+      uses: nerdyscout/kicad-exports@v2.3
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom-mini/gerber

--- a/.github/workflows/release-corne-cherry.yml
+++ b/.github/workflows/release-corne-cherry.yml
@@ -32,12 +32,28 @@ jobs:
         dir: plates/pcb/bottom/gerber
         board: plates/pcb/bottom/corne-bottom-plate.kicad_pcb
         schema: plates/pcb/bottom/corne-bottom-plate.sch
+    - name: Export top plate mini gerber
+      uses: nerdyscout/kicad-exports@v2.0
+      with:
+        config: .kiplot.yml
+        dir: plates/pcb/top-mini/gerber
+        board: plates/pcb/top-mini/corne-top-plate.kicad_pcb
+        schema: plates/pcb/top-mini/corne-top-plate.sch
+    - name: Export bottom plate mini gerber
+      uses: nerdyscout/kicad-exports@v2.0
+      with:
+        config: .kiplot.yml
+        dir: plates/pcb/bottom-mini/gerber
+        board: plates/pcb/bottom-mini/corne-bottom-plate.kicad_pcb
+        schema: plates/pcb/bottom-mini/corne-bottom-plate.sch
 
     - name: Zip Gerber files
       run: |
           zip -r --junk-paths corne-cherry-gerber.zip corne-cherry/gerber
           zip -r --junk-paths plates-top-gerber.zip plates/pcb/top/gerber
+          zip -r --junk-paths plates-top-mini-gerber.zip plates/pcb/top-mini/gerber
           zip -r --junk-paths plates-bottom-gerber.zip plates/pcb/bottom/gerber
+          zip -r --junk-paths plates-bottom-mini-gerber.zip plates/pcb/bottom-mini/gerber
           zip -r --junk-paths plates.zip plates/common
 
     - name: Release to GitHub

--- a/.github/workflows/release-corne-cherry.yml
+++ b/.github/workflows/release-corne-cherry.yml
@@ -12,32 +12,32 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Export corne-cherry gerber
-      uses: nerdyscout/kicad-exports@v2.0
+      uses: nerdyscout/kicad-exports@v2.1
       with:
         config: .kiplot.yml
         dir: corne-cherry/gerber
         board: corne-cherry/pcb/corne-cherry.kicad_pcb
         schema: corne-cherry/pcb/corne-cherry.kicad_sch
     - name: Export top plate gerber
-      uses: nerdyscout/kicad-exports@v2.0
+      uses: nerdyscout/kicad-exports@v2.1
       with:
         config: .kiplot.yml
         dir: plates/pcb/top/gerber
         board: plates/pcb/top/corne-top-plate.kicad_pcb
     - name: Export bottom plate gerber
-      uses: nerdyscout/kicad-exports@v2.0
+      uses: nerdyscout/kicad-exports@v2.1
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom/gerber
         board: plates/pcb/bottom/corne-bottom-plate.kicad_pcb
     - name: Export top plate mini gerber
-      uses: nerdyscout/kicad-exports@v2.0
+      uses: nerdyscout/kicad-exports@v2.1
       with:
         config: .kiplot.yml
         dir: plates/pcb/top-mini/gerber
         board: plates/pcb/top-mini/corne-top-plate.kicad_pcb
     - name: Export bottom plate mini gerber
-      uses: nerdyscout/kicad-exports@v2.0
+      uses: nerdyscout/kicad-exports@v2.1
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom-mini/gerber

--- a/.github/workflows/release-corne-cherry.yml
+++ b/.github/workflows/release-corne-cherry.yml
@@ -17,35 +17,31 @@ jobs:
         config: .kiplot.yml
         dir: corne-cherry/gerber
         board: corne-cherry/pcb/corne-cherry.kicad_pcb
-        schema: corne-cherry/pcb/corne-cherry.sch
+        schema: corne-cherry/pcb/corne-cherry.kicad_sch
     - name: Export top plate gerber
       uses: nerdyscout/kicad-exports@v2.0
       with:
         config: .kiplot.yml
         dir: plates/pcb/top/gerber
         board: plates/pcb/top/corne-top-plate.kicad_pcb
-        schema: plates/pcb/top/corne-top-plate.sch
     - name: Export bottom plate gerber
       uses: nerdyscout/kicad-exports@v2.0
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom/gerber
         board: plates/pcb/bottom/corne-bottom-plate.kicad_pcb
-        schema: plates/pcb/bottom/corne-bottom-plate.sch
     - name: Export top plate mini gerber
       uses: nerdyscout/kicad-exports@v2.0
       with:
         config: .kiplot.yml
         dir: plates/pcb/top-mini/gerber
         board: plates/pcb/top-mini/corne-top-plate.kicad_pcb
-        schema: plates/pcb/top-mini/corne-top-plate.sch
     - name: Export bottom plate mini gerber
       uses: nerdyscout/kicad-exports@v2.0
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom-mini/gerber
         board: plates/pcb/bottom-mini/corne-bottom-plate.kicad_pcb
-        schema: plates/pcb/bottom-mini/corne-bottom-plate.sch
 
     - name: Zip Gerber files
       run: |

--- a/.github/workflows/release-corne-cherry.yml
+++ b/.github/workflows/release-corne-cherry.yml
@@ -12,32 +12,32 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Export corne-cherry gerber
-      uses: nerdyscout/kicad-exports@v2.3
+      uses: INTI-CMNB/KiBot@v2
       with:
         config: .kiplot.yml
         dir: corne-cherry/gerber
         board: corne-cherry/pcb/corne-cherry.kicad_pcb
         schema: corne-cherry/pcb/corne-cherry.kicad_sch
     - name: Export top plate gerber
-      uses: nerdyscout/kicad-exports@v2.3
+      uses: INTI-CMNB/KiBot@v2
       with:
         config: .kiplot.yml
         dir: plates/pcb/top/gerber
         board: plates/pcb/top/corne-top-plate.kicad_pcb
     - name: Export bottom plate gerber
-      uses: nerdyscout/kicad-exports@v2.3
+      uses: INTI-CMNB/KiBot@v2
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom/gerber
         board: plates/pcb/bottom/corne-bottom-plate.kicad_pcb
     - name: Export top plate mini gerber
-      uses: nerdyscout/kicad-exports@v2.3
+      uses: INTI-CMNB/KiBot@v2
       with:
         config: .kiplot.yml
         dir: plates/pcb/top-mini/gerber
         board: plates/pcb/top-mini/corne-top-plate.kicad_pcb
     - name: Export bottom plate mini gerber
-      uses: nerdyscout/kicad-exports@v2.3
+      uses: INTI-CMNB/KiBot@v2
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom-mini/gerber

--- a/.github/workflows/release-corne-cherry.yml
+++ b/.github/workflows/release-corne-cherry.yml
@@ -12,32 +12,32 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Export corne-cherry gerber
-      uses: INTI-CMNB/KiBot@v2
+      uses: INTI-CMNB/KiBot@v2_k6
       with:
         config: .kiplot.yml
         dir: corne-cherry/gerber
         board: corne-cherry/pcb/corne-cherry.kicad_pcb
         schema: corne-cherry/pcb/corne-cherry.kicad_sch
     - name: Export top plate gerber
-      uses: INTI-CMNB/KiBot@v2
+      uses: INTI-CMNB/KiBot@v2_k6
       with:
         config: .kiplot.yml
         dir: plates/pcb/top/gerber
         board: plates/pcb/top/corne-top-plate.kicad_pcb
     - name: Export bottom plate gerber
-      uses: INTI-CMNB/KiBot@v2
+      uses: INTI-CMNB/KiBot@v2_k6
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom/gerber
         board: plates/pcb/bottom/corne-bottom-plate.kicad_pcb
     - name: Export top plate mini gerber
-      uses: INTI-CMNB/KiBot@v2
+      uses: INTI-CMNB/KiBot@v2_k6
       with:
         config: .kiplot.yml
         dir: plates/pcb/top-mini/gerber
         board: plates/pcb/top-mini/corne-top-plate.kicad_pcb
     - name: Export bottom plate mini gerber
-      uses: INTI-CMNB/KiBot@v2
+      uses: INTI-CMNB/KiBot@v2_k6
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom-mini/gerber

--- a/.github/workflows/release-corne-cherry.yml
+++ b/.github/workflows/release-corne-cherry.yml
@@ -12,32 +12,32 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Export corne-cherry gerber
-      uses: nerdyscout/kicad-exports@v2.1
+      uses: nerdyscout/kicad-exports@v2.2
       with:
         config: .kiplot.yml
         dir: corne-cherry/gerber
         board: corne-cherry/pcb/corne-cherry.kicad_pcb
         schema: corne-cherry/pcb/corne-cherry.kicad_sch
     - name: Export top plate gerber
-      uses: nerdyscout/kicad-exports@v2.1
+      uses: nerdyscout/kicad-exports@v2.2
       with:
         config: .kiplot.yml
         dir: plates/pcb/top/gerber
         board: plates/pcb/top/corne-top-plate.kicad_pcb
     - name: Export bottom plate gerber
-      uses: nerdyscout/kicad-exports@v2.1
+      uses: nerdyscout/kicad-exports@v2.2
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom/gerber
         board: plates/pcb/bottom/corne-bottom-plate.kicad_pcb
     - name: Export top plate mini gerber
-      uses: nerdyscout/kicad-exports@v2.1
+      uses: nerdyscout/kicad-exports@v2.2
       with:
         config: .kiplot.yml
         dir: plates/pcb/top-mini/gerber
         board: plates/pcb/top-mini/corne-top-plate.kicad_pcb
     - name: Export bottom plate mini gerber
-      uses: nerdyscout/kicad-exports@v2.1
+      uses: nerdyscout/kicad-exports@v2.2
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom-mini/gerber

--- a/.github/workflows/release-corne-chocolate.yml
+++ b/.github/workflows/release-corne-chocolate.yml
@@ -17,35 +17,31 @@ jobs:
         config: .kiplot.yml
         dir: corne-chocolate/gerber
         board: corne-chocolate/pcb/corne-chocolate.kicad_pcb
-        schema: corne-chocolate/pcb/corne-chocolate.sch
+        schema: corne-chocolate/pcb/corne-chocolate.kicad_sch
     - name: Export top plate gerber
       uses: nerdyscout/kicad-exports@v2.0
       with:
         config: .kiplot.yml
         dir: plates/pcb/top/gerber
         board: plates/pcb/top/corne-top-plate.kicad_pcb
-        schema: plates/pcb/top/corne-top-plate.sch
     - name: Export bottom plate gerber
       uses: nerdyscout/kicad-exports@v2.0
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom/gerber
         board: plates/pcb/bottom/corne-bottom-plate.kicad_pcb
-        schema: plates/pcb/bottom/corne-bottom-plate.sch
     - name: Export top plate mini gerber
       uses: nerdyscout/kicad-exports@v2.0
       with:
         config: .kiplot.yml
         dir: plates/pcb/top-mini/gerber
         board: plates/pcb/top-mini/corne-top-plate.kicad_pcb
-        schema: plates/pcb/top-mini/corne-top-plate.sch
     - name: Export bottom plate mini gerber
       uses: nerdyscout/kicad-exports@v2.0
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom-mini/gerber
         board: plates/pcb/bottom-mini/corne-bottom-plate.kicad_pcb
-        schema: plates/pcb/bottom-mini/corne-bottom-plate.sch
 
     - name: Zip Gerber files
       run: |

--- a/.github/workflows/release-corne-chocolate.yml
+++ b/.github/workflows/release-corne-chocolate.yml
@@ -32,12 +32,28 @@ jobs:
         dir: plates/pcb/bottom/gerber
         board: plates/pcb/bottom/corne-bottom-plate.kicad_pcb
         schema: plates/pcb/bottom/corne-bottom-plate.sch
+    - name: Export top plate mini gerber
+      uses: nerdyscout/kicad-exports@v2.0
+      with:
+        config: .kiplot.yml
+        dir: plates/pcb/top-mini/gerber
+        board: plates/pcb/top-mini/corne-top-plate.kicad_pcb
+        schema: plates/pcb/top-mini/corne-top-plate.sch
+    - name: Export bottom plate mini gerber
+      uses: nerdyscout/kicad-exports@v2.0
+      with:
+        config: .kiplot.yml
+        dir: plates/pcb/bottom-mini/gerber
+        board: plates/pcb/bottom-mini/corne-bottom-plate.kicad_pcb
+        schema: plates/pcb/bottom-mini/corne-bottom-plate.sch
 
     - name: Zip Gerber files
       run: |
           zip -r --junk-paths corne-chocolate-gerber.zip corne-chocolate/gerber
           zip -r --junk-paths plates-top-gerber.zip plates/pcb/top/gerber
+          zip -r --junk-paths plates-top-mini-gerber.zip plates/pcb/top-mini/gerber
           zip -r --junk-paths plates-bottom-gerber.zip plates/pcb/bottom/gerber
+          zip -r --junk-paths plates-bottom-mini-gerber.zip plates/pcb/bottom-mini/gerber
           zip -r --junk-paths plates.zip plates/common
 
     - name: Release to GitHub

--- a/.github/workflows/release-corne-chocolate.yml
+++ b/.github/workflows/release-corne-chocolate.yml
@@ -12,32 +12,32 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Export corne-chocolate gerber
-      uses: nerdyscout/kicad-exports@v2.3
+      uses: INTI-CMNB/KiBot@v2
       with:
         config: .kiplot.yml
         dir: corne-chocolate/gerber
         board: corne-chocolate/pcb/corne-chocolate.kicad_pcb
         schema: corne-chocolate/pcb/corne-chocolate.kicad_sch
     - name: Export top plate gerber
-      uses: nerdyscout/kicad-exports@v2.3
+      uses: INTI-CMNB/KiBot@v2
       with:
         config: .kiplot.yml
         dir: plates/pcb/top/gerber
         board: plates/pcb/top/corne-top-plate.kicad_pcb
     - name: Export bottom plate gerber
-      uses: nerdyscout/kicad-exports@v2.3
+      uses: INTI-CMNB/KiBot@v2
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom/gerber
         board: plates/pcb/bottom/corne-bottom-plate.kicad_pcb
     - name: Export top plate mini gerber
-      uses: nerdyscout/kicad-exports@v2.3
+      uses: INTI-CMNB/KiBot@v2
       with:
         config: .kiplot.yml
         dir: plates/pcb/top-mini/gerber
         board: plates/pcb/top-mini/corne-top-plate.kicad_pcb
     - name: Export bottom plate mini gerber
-      uses: nerdyscout/kicad-exports@v2.3
+      uses: INTI-CMNB/KiBot@v2
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom-mini/gerber

--- a/.github/workflows/release-corne-chocolate.yml
+++ b/.github/workflows/release-corne-chocolate.yml
@@ -12,32 +12,32 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Export corne-chocolate gerber
-      uses: nerdyscout/kicad-exports@v2.0
+      uses: nerdyscout/kicad-exports@v2.1
       with:
         config: .kiplot.yml
         dir: corne-chocolate/gerber
         board: corne-chocolate/pcb/corne-chocolate.kicad_pcb
         schema: corne-chocolate/pcb/corne-chocolate.kicad_sch
     - name: Export top plate gerber
-      uses: nerdyscout/kicad-exports@v2.0
+      uses: nerdyscout/kicad-exports@v2.1
       with:
         config: .kiplot.yml
         dir: plates/pcb/top/gerber
         board: plates/pcb/top/corne-top-plate.kicad_pcb
     - name: Export bottom plate gerber
-      uses: nerdyscout/kicad-exports@v2.0
+      uses: nerdyscout/kicad-exports@v2.1
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom/gerber
         board: plates/pcb/bottom/corne-bottom-plate.kicad_pcb
     - name: Export top plate mini gerber
-      uses: nerdyscout/kicad-exports@v2.0
+      uses: nerdyscout/kicad-exports@v2.1
       with:
         config: .kiplot.yml
         dir: plates/pcb/top-mini/gerber
         board: plates/pcb/top-mini/corne-top-plate.kicad_pcb
     - name: Export bottom plate mini gerber
-      uses: nerdyscout/kicad-exports@v2.0
+      uses: nerdyscout/kicad-exports@v2.1
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom-mini/gerber

--- a/.github/workflows/release-corne-chocolate.yml
+++ b/.github/workflows/release-corne-chocolate.yml
@@ -12,32 +12,32 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Export corne-chocolate gerber
-      uses: nerdyscout/kicad-exports@v2.2
+      uses: nerdyscout/kicad-exports@v2.3
       with:
         config: .kiplot.yml
         dir: corne-chocolate/gerber
         board: corne-chocolate/pcb/corne-chocolate.kicad_pcb
         schema: corne-chocolate/pcb/corne-chocolate.kicad_sch
     - name: Export top plate gerber
-      uses: nerdyscout/kicad-exports@v2.2
+      uses: nerdyscout/kicad-exports@v2.3
       with:
         config: .kiplot.yml
         dir: plates/pcb/top/gerber
         board: plates/pcb/top/corne-top-plate.kicad_pcb
     - name: Export bottom plate gerber
-      uses: nerdyscout/kicad-exports@v2.2
+      uses: nerdyscout/kicad-exports@v2.3
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom/gerber
         board: plates/pcb/bottom/corne-bottom-plate.kicad_pcb
     - name: Export top plate mini gerber
-      uses: nerdyscout/kicad-exports@v2.2
+      uses: nerdyscout/kicad-exports@v2.3
       with:
         config: .kiplot.yml
         dir: plates/pcb/top-mini/gerber
         board: plates/pcb/top-mini/corne-top-plate.kicad_pcb
     - name: Export bottom plate mini gerber
-      uses: nerdyscout/kicad-exports@v2.2
+      uses: nerdyscout/kicad-exports@v2.3
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom-mini/gerber

--- a/.github/workflows/release-corne-chocolate.yml
+++ b/.github/workflows/release-corne-chocolate.yml
@@ -12,32 +12,32 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Export corne-chocolate gerber
-      uses: INTI-CMNB/KiBot@v2
+      uses: INTI-CMNB/KiBot@v2_k6
       with:
         config: .kiplot.yml
         dir: corne-chocolate/gerber
         board: corne-chocolate/pcb/corne-chocolate.kicad_pcb
         schema: corne-chocolate/pcb/corne-chocolate.kicad_sch
     - name: Export top plate gerber
-      uses: INTI-CMNB/KiBot@v2
+      uses: INTI-CMNB/KiBot@v2_k6
       with:
         config: .kiplot.yml
         dir: plates/pcb/top/gerber
         board: plates/pcb/top/corne-top-plate.kicad_pcb
     - name: Export bottom plate gerber
-      uses: INTI-CMNB/KiBot@v2
+      uses: INTI-CMNB/KiBot@v2_k6
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom/gerber
         board: plates/pcb/bottom/corne-bottom-plate.kicad_pcb
     - name: Export top plate mini gerber
-      uses: INTI-CMNB/KiBot@v2
+      uses: INTI-CMNB/KiBot@v2_k6
       with:
         config: .kiplot.yml
         dir: plates/pcb/top-mini/gerber
         board: plates/pcb/top-mini/corne-top-plate.kicad_pcb
     - name: Export bottom plate mini gerber
-      uses: INTI-CMNB/KiBot@v2
+      uses: INTI-CMNB/KiBot@v2_k6
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom-mini/gerber

--- a/.github/workflows/release-corne-chocolate.yml
+++ b/.github/workflows/release-corne-chocolate.yml
@@ -12,32 +12,32 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Export corne-chocolate gerber
-      uses: nerdyscout/kicad-exports@v2.1
+      uses: nerdyscout/kicad-exports@v2.2
       with:
         config: .kiplot.yml
         dir: corne-chocolate/gerber
         board: corne-chocolate/pcb/corne-chocolate.kicad_pcb
         schema: corne-chocolate/pcb/corne-chocolate.kicad_sch
     - name: Export top plate gerber
-      uses: nerdyscout/kicad-exports@v2.1
+      uses: nerdyscout/kicad-exports@v2.2
       with:
         config: .kiplot.yml
         dir: plates/pcb/top/gerber
         board: plates/pcb/top/corne-top-plate.kicad_pcb
     - name: Export bottom plate gerber
-      uses: nerdyscout/kicad-exports@v2.1
+      uses: nerdyscout/kicad-exports@v2.2
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom/gerber
         board: plates/pcb/bottom/corne-bottom-plate.kicad_pcb
     - name: Export top plate mini gerber
-      uses: nerdyscout/kicad-exports@v2.1
+      uses: nerdyscout/kicad-exports@v2.2
       with:
         config: .kiplot.yml
         dir: plates/pcb/top-mini/gerber
         board: plates/pcb/top-mini/corne-top-plate.kicad_pcb
     - name: Export bottom plate mini gerber
-      uses: nerdyscout/kicad-exports@v2.1
+      uses: nerdyscout/kicad-exports@v2.2
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom-mini/gerber

--- a/.github/workflows/release-corne-classic.yml
+++ b/.github/workflows/release-corne-classic.yml
@@ -12,32 +12,32 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Export corne-classic gerber
-      uses: nerdyscout/kicad-exports@v2.2
+      uses: nerdyscout/kicad-exports@v2.3
       with:
         config: .kiplot.yml
         dir: corne-classic/gerber
         board: corne-classic/pcb/corne-classic.kicad_pcb
         schema: corne-classic/pcb/corne-classic.kicad_sch
     - name: Export top plate gerber
-      uses: nerdyscout/kicad-exports@v2.2
+      uses: nerdyscout/kicad-exports@v2.3
       with:
         config: .kiplot.yml
         dir: plates/pcb/top/gerber
         board: plates/pcb/top/corne-top-plate.kicad_pcb
     - name: Export bottom plate gerber
-      uses: nerdyscout/kicad-exports@v2.2
+      uses: nerdyscout/kicad-exports@v2.3
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom/gerber
         board: plates/pcb/bottom/corne-bottom-plate.kicad_pcb
     - name: Export top plate mini gerber
-      uses: nerdyscout/kicad-exports@v2.2
+      uses: nerdyscout/kicad-exports@v2.3
       with:
         config: .kiplot.yml
         dir: plates/pcb/top-mini/gerber
         board: plates/pcb/top-mini/corne-top-plate.kicad_pcb
     - name: Export bottom plate mini gerber
-      uses: nerdyscout/kicad-exports@v2.2
+      uses: nerdyscout/kicad-exports@v2.3
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom-mini/gerber

--- a/.github/workflows/release-corne-classic.yml
+++ b/.github/workflows/release-corne-classic.yml
@@ -12,32 +12,32 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Export corne-classic gerber
-      uses: INTI-CMNB/KiBot@v2
+      uses: INTI-CMNB/KiBot@v2_k6
       with:
         config: .kiplot.yml
         dir: corne-classic/gerber
         board: corne-classic/pcb/corne-classic.kicad_pcb
         schema: corne-classic/pcb/corne-classic.kicad_sch
     - name: Export top plate gerber
-      uses: INTI-CMNB/KiBot@v2
+      uses: INTI-CMNB/KiBot@v2_k6
       with:
         config: .kiplot.yml
         dir: plates/pcb/top/gerber
         board: plates/pcb/top/corne-top-plate.kicad_pcb
     - name: Export bottom plate gerber
-      uses: INTI-CMNB/KiBot@v2
+      uses: INTI-CMNB/KiBot@v2_k6
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom/gerber
         board: plates/pcb/bottom/corne-bottom-plate.kicad_pcb
     - name: Export top plate mini gerber
-      uses: INTI-CMNB/KiBot@v2
+      uses: INTI-CMNB/KiBot@v2_k6
       with:
         config: .kiplot.yml
         dir: plates/pcb/top-mini/gerber
         board: plates/pcb/top-mini/corne-top-plate.kicad_pcb
     - name: Export bottom plate mini gerber
-      uses: INTI-CMNB/KiBot@v2
+      uses: INTI-CMNB/KiBot@v2_k6
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom-mini/gerber

--- a/.github/workflows/release-corne-classic.yml
+++ b/.github/workflows/release-corne-classic.yml
@@ -17,35 +17,31 @@ jobs:
         config: .kiplot.yml
         dir: corne-classic/gerber
         board: corne-classic/pcb/corne-classic.kicad_pcb
-        schema: corne-classic/pcb/corne-classic.sch
+        schema: corne-classic/pcb/corne-classic.kicad_sch
     - name: Export top plate gerber
       uses: nerdyscout/kicad-exports@v2.0
       with:
         config: .kiplot.yml
         dir: plates/pcb/top/gerber
         board: plates/pcb/top/corne-top-plate.kicad_pcb
-        schema: plates/pcb/top/corne-top-plate.sch
     - name: Export bottom plate gerber
       uses: nerdyscout/kicad-exports@v2.0
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom/gerber
         board: plates/pcb/bottom/corne-bottom-plate.kicad_pcb
-        schema: plates/pcb/bottom/corne-bottom-plate.sch
     - name: Export top plate mini gerber
       uses: nerdyscout/kicad-exports@v2.0
       with:
         config: .kiplot.yml
         dir: plates/pcb/top-mini/gerber
         board: plates/pcb/top-mini/corne-top-plate.kicad_pcb
-        schema: plates/pcb/top-mini/corne-top-plate.sch
     - name: Export bottom plate mini gerber
       uses: nerdyscout/kicad-exports@v2.0
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom-mini/gerber
         board: plates/pcb/bottom-mini/corne-bottom-plate.kicad_pcb
-        schema: plates/pcb/bottom-mini/corne-bottom-plate.sch
 
     - name: Zip Gerber files
       run: |

--- a/.github/workflows/release-corne-classic.yml
+++ b/.github/workflows/release-corne-classic.yml
@@ -12,32 +12,32 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Export corne-classic gerber
-      uses: nerdyscout/kicad-exports@v2.0
+      uses: nerdyscout/kicad-exports@v2.1
       with:
         config: .kiplot.yml
         dir: corne-classic/gerber
         board: corne-classic/pcb/corne-classic.kicad_pcb
         schema: corne-classic/pcb/corne-classic.kicad_sch
     - name: Export top plate gerber
-      uses: nerdyscout/kicad-exports@v2.0
+      uses: nerdyscout/kicad-exports@v2.1
       with:
         config: .kiplot.yml
         dir: plates/pcb/top/gerber
         board: plates/pcb/top/corne-top-plate.kicad_pcb
     - name: Export bottom plate gerber
-      uses: nerdyscout/kicad-exports@v2.0
+      uses: nerdyscout/kicad-exports@v2.1
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom/gerber
         board: plates/pcb/bottom/corne-bottom-plate.kicad_pcb
     - name: Export top plate mini gerber
-      uses: nerdyscout/kicad-exports@v2.0
+      uses: nerdyscout/kicad-exports@v2.1
       with:
         config: .kiplot.yml
         dir: plates/pcb/top-mini/gerber
         board: plates/pcb/top-mini/corne-top-plate.kicad_pcb
     - name: Export bottom plate mini gerber
-      uses: nerdyscout/kicad-exports@v2.0
+      uses: nerdyscout/kicad-exports@v2.1
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom-mini/gerber

--- a/.github/workflows/release-corne-classic.yml
+++ b/.github/workflows/release-corne-classic.yml
@@ -32,12 +32,28 @@ jobs:
         dir: plates/pcb/bottom/gerber
         board: plates/pcb/bottom/corne-bottom-plate.kicad_pcb
         schema: plates/pcb/bottom/corne-bottom-plate.sch
+    - name: Export top plate mini gerber
+      uses: nerdyscout/kicad-exports@v2.0
+      with:
+        config: .kiplot.yml
+        dir: plates/pcb/top-mini/gerber
+        board: plates/pcb/top-mini/corne-top-plate.kicad_pcb
+        schema: plates/pcb/top-mini/corne-top-plate.sch
+    - name: Export bottom plate mini gerber
+      uses: nerdyscout/kicad-exports@v2.0
+      with:
+        config: .kiplot.yml
+        dir: plates/pcb/bottom-mini/gerber
+        board: plates/pcb/bottom-mini/corne-bottom-plate.kicad_pcb
+        schema: plates/pcb/bottom-mini/corne-bottom-plate.sch
 
     - name: Zip Gerber files
       run: |
           zip -r --junk-paths corne-classic-gerber.zip corne-classic/gerber
           zip -r --junk-paths plates-top-gerber.zip plates/pcb/top/gerber
+          zip -r --junk-paths plates-top-mini-gerber.zip plates/pcb/top-mini/gerber
           zip -r --junk-paths plates-bottom-gerber.zip plates/pcb/bottom/gerber
+          zip -r --junk-paths plates-bottom-mini-gerber.zip plates/pcb/bottom-mini/gerber
           zip -r --junk-paths plates.zip plates/common
 
     - name: Release to GitHub

--- a/.github/workflows/release-corne-classic.yml
+++ b/.github/workflows/release-corne-classic.yml
@@ -12,32 +12,32 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Export corne-classic gerber
-      uses: nerdyscout/kicad-exports@v2.3
+      uses: INTI-CMNB/KiBot@v2
       with:
         config: .kiplot.yml
         dir: corne-classic/gerber
         board: corne-classic/pcb/corne-classic.kicad_pcb
         schema: corne-classic/pcb/corne-classic.kicad_sch
     - name: Export top plate gerber
-      uses: nerdyscout/kicad-exports@v2.3
+      uses: INTI-CMNB/KiBot@v2
       with:
         config: .kiplot.yml
         dir: plates/pcb/top/gerber
         board: plates/pcb/top/corne-top-plate.kicad_pcb
     - name: Export bottom plate gerber
-      uses: nerdyscout/kicad-exports@v2.3
+      uses: INTI-CMNB/KiBot@v2
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom/gerber
         board: plates/pcb/bottom/corne-bottom-plate.kicad_pcb
     - name: Export top plate mini gerber
-      uses: nerdyscout/kicad-exports@v2.3
+      uses: INTI-CMNB/KiBot@v2
       with:
         config: .kiplot.yml
         dir: plates/pcb/top-mini/gerber
         board: plates/pcb/top-mini/corne-top-plate.kicad_pcb
     - name: Export bottom plate mini gerber
-      uses: nerdyscout/kicad-exports@v2.3
+      uses: INTI-CMNB/KiBot@v2
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom-mini/gerber

--- a/.github/workflows/release-corne-classic.yml
+++ b/.github/workflows/release-corne-classic.yml
@@ -12,32 +12,32 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Export corne-classic gerber
-      uses: nerdyscout/kicad-exports@v2.1
+      uses: nerdyscout/kicad-exports@v2.2
       with:
         config: .kiplot.yml
         dir: corne-classic/gerber
         board: corne-classic/pcb/corne-classic.kicad_pcb
         schema: corne-classic/pcb/corne-classic.kicad_sch
     - name: Export top plate gerber
-      uses: nerdyscout/kicad-exports@v2.1
+      uses: nerdyscout/kicad-exports@v2.2
       with:
         config: .kiplot.yml
         dir: plates/pcb/top/gerber
         board: plates/pcb/top/corne-top-plate.kicad_pcb
     - name: Export bottom plate gerber
-      uses: nerdyscout/kicad-exports@v2.1
+      uses: nerdyscout/kicad-exports@v2.2
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom/gerber
         board: plates/pcb/bottom/corne-bottom-plate.kicad_pcb
     - name: Export top plate mini gerber
-      uses: nerdyscout/kicad-exports@v2.1
+      uses: nerdyscout/kicad-exports@v2.2
       with:
         config: .kiplot.yml
         dir: plates/pcb/top-mini/gerber
         board: plates/pcb/top-mini/corne-top-plate.kicad_pcb
     - name: Export bottom plate mini gerber
-      uses: nerdyscout/kicad-exports@v2.1
+      uses: nerdyscout/kicad-exports@v2.2
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom-mini/gerber

--- a/.github/workflows/release-corne-light.yml
+++ b/.github/workflows/release-corne-light.yml
@@ -12,38 +12,38 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Export corne-light gerber
-      uses: nerdyscout/kicad-exports@v2.3
+      uses: INTI-CMNB/KiBot@v2
       with:
         config: .kiplot.yml
         dir: corne-light/gerber
         board: corne-light/pcb/corne-light.kicad_pcb
         schema: corne-light/pcb/corne-light.kicad_sch
     - name: Export top plate gerber
-      uses: nerdyscout/kicad-exports@v2.3
+      uses: INTI-CMNB/KiBot@v2
       with:
         config: .kiplot.yml
         dir: plates/pcb/top/gerber
         board: plates/pcb/top/corne-top-plate.kicad_pcb
     - name: Export bottom plate gerber
-      uses: nerdyscout/kicad-exports@v2.3
+      uses: INTI-CMNB/KiBot@v2
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom/gerber
         board: plates/pcb/bottom/corne-bottom-plate.kicad_pcb
     - name: Export top plate mini gerber
-      uses: nerdyscout/kicad-exports@v2.3
+      uses: INTI-CMNB/KiBot@v2
       with:
         config: .kiplot.yml
         dir: plates/pcb/top-mini/gerber
         board: plates/pcb/top-mini/corne-top-plate.kicad_pcb
     - name: Export bottom plate mini gerber
-      uses: nerdyscout/kicad-exports@v2.3
+      uses: INTI-CMNB/KiBot@v2
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom-mini/gerber
         board: plates/pcb/bottom-mini/corne-bottom-plate.kicad_pcb
     - name: Export top-alps plate gerber
-      uses: nerdyscout/kicad-exports@v2.3
+      uses: INTI-CMNB/KiBot@v2
       with:
         config: .kiplot.yml
         dir: plates/pcb/top-alps/gerber

--- a/.github/workflows/release-corne-light.yml
+++ b/.github/workflows/release-corne-light.yml
@@ -12,38 +12,38 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Export corne-light gerber
-      uses: nerdyscout/kicad-exports@v2.1
+      uses: nerdyscout/kicad-exports@v2.2
       with:
         config: .kiplot.yml
         dir: corne-light/gerber
         board: corne-light/pcb/corne-light.kicad_pcb
         schema: corne-light/pcb/corne-light.kicad_sch
     - name: Export top plate gerber
-      uses: nerdyscout/kicad-exports@v2.1
+      uses: nerdyscout/kicad-exports@v2.2
       with:
         config: .kiplot.yml
         dir: plates/pcb/top/gerber
         board: plates/pcb/top/corne-top-plate.kicad_pcb
     - name: Export bottom plate gerber
-      uses: nerdyscout/kicad-exports@v2.1
+      uses: nerdyscout/kicad-exports@v2.2
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom/gerber
         board: plates/pcb/bottom/corne-bottom-plate.kicad_pcb
     - name: Export top plate mini gerber
-      uses: nerdyscout/kicad-exports@v2.1
+      uses: nerdyscout/kicad-exports@v2.2
       with:
         config: .kiplot.yml
         dir: plates/pcb/top-mini/gerber
         board: plates/pcb/top-mini/corne-top-plate.kicad_pcb
     - name: Export bottom plate mini gerber
-      uses: nerdyscout/kicad-exports@v2.1
+      uses: nerdyscout/kicad-exports@v2.2
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom-mini/gerber
         board: plates/pcb/bottom-mini/corne-bottom-plate.kicad_pcb
     - name: Export top-alps plate gerber
-      uses: nerdyscout/kicad-exports@v2.1
+      uses: nerdyscout/kicad-exports@v2.2
       with:
         config: .kiplot.yml
         dir: plates/pcb/top-alps/gerber

--- a/.github/workflows/release-corne-light.yml
+++ b/.github/workflows/release-corne-light.yml
@@ -60,8 +60,8 @@ jobs:
           zip -r --junk-paths plates-top-gerber.zip plates/pcb/top/gerber
           zip -r --junk-paths plates-top-mini-gerber.zip plates/pcb/top-mini/gerber
           zip -r --junk-paths plates-top-alps-gerber.zip plates/pcb/top-alps/gerber
-          zip -r --junk-paths plates-bottom-gerber.zip plates/pcb/bottom-mini/gerber
-          zip -r --junk-paths plates-bottom-mini-gerber.zip plates/pcb/bottom/gerber
+          zip -r --junk-paths plates-bottom-gerber.zip plates/pcb/bottom/gerber
+          zip -r --junk-paths plates-bottom-mini-gerber.zip plates/pcb/bottom-mini/gerber
           zip -r --junk-paths plates.zip plates/common
           zip -r --junk-paths plates-alps.zip plates/alps
           zip -r --junk-paths plates-mini.zip plates/mini

--- a/.github/workflows/release-corne-light.yml
+++ b/.github/workflows/release-corne-light.yml
@@ -12,38 +12,38 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Export corne-light gerber
-      uses: nerdyscout/kicad-exports@v2.0
+      uses: nerdyscout/kicad-exports@v2.1
       with:
         config: .kiplot.yml
         dir: corne-light/gerber
         board: corne-light/pcb/corne-light.kicad_pcb
         schema: corne-light/pcb/corne-light.kicad_sch
     - name: Export top plate gerber
-      uses: nerdyscout/kicad-exports@v2.0
+      uses: nerdyscout/kicad-exports@v2.1
       with:
         config: .kiplot.yml
         dir: plates/pcb/top/gerber
         board: plates/pcb/top/corne-top-plate.kicad_pcb
     - name: Export bottom plate gerber
-      uses: nerdyscout/kicad-exports@v2.0
+      uses: nerdyscout/kicad-exports@v2.1
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom/gerber
         board: plates/pcb/bottom/corne-bottom-plate.kicad_pcb
     - name: Export top plate mini gerber
-      uses: nerdyscout/kicad-exports@v2.0
+      uses: nerdyscout/kicad-exports@v2.1
       with:
         config: .kiplot.yml
         dir: plates/pcb/top-mini/gerber
         board: plates/pcb/top-mini/corne-top-plate.kicad_pcb
     - name: Export bottom plate mini gerber
-      uses: nerdyscout/kicad-exports@v2.0
+      uses: nerdyscout/kicad-exports@v2.1
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom-mini/gerber
         board: plates/pcb/bottom-mini/corne-bottom-plate.kicad_pcb
     - name: Export top-alps plate gerber
-      uses: nerdyscout/kicad-exports@v2.0
+      uses: nerdyscout/kicad-exports@v2.1
       with:
         config: .kiplot.yml
         dir: plates/pcb/top-alps/gerber

--- a/.github/workflows/release-corne-light.yml
+++ b/.github/workflows/release-corne-light.yml
@@ -17,42 +17,37 @@ jobs:
         config: .kiplot.yml
         dir: corne-light/gerber
         board: corne-light/pcb/corne-light.kicad_pcb
-        schema: corne-light/pcb/corne-light.sch
+        schema: corne-light/pcb/corne-light.kicad_sch
     - name: Export top plate gerber
       uses: nerdyscout/kicad-exports@v2.0
       with:
         config: .kiplot.yml
         dir: plates/pcb/top/gerber
         board: plates/pcb/top/corne-top-plate.kicad_pcb
-        schema: plates/pcb/top/corne-top-plate.sch
     - name: Export bottom plate gerber
       uses: nerdyscout/kicad-exports@v2.0
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom/gerber
         board: plates/pcb/bottom/corne-bottom-plate.kicad_pcb
-        schema: plates/pcb/bottom/corne-bottom-plate.sch
     - name: Export top plate mini gerber
       uses: nerdyscout/kicad-exports@v2.0
       with:
         config: .kiplot.yml
         dir: plates/pcb/top-mini/gerber
         board: plates/pcb/top-mini/corne-top-plate.kicad_pcb
-        schema: plates/pcb/top-mini/corne-top-plate.sch
     - name: Export bottom plate mini gerber
       uses: nerdyscout/kicad-exports@v2.0
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom-mini/gerber
         board: plates/pcb/bottom-mini/corne-bottom-plate.kicad_pcb
-        schema: plates/pcb/bottom-mini/corne-bottom-plate.sch
     - name: Export top-alps plate gerber
       uses: nerdyscout/kicad-exports@v2.0
       with:
         config: .kiplot.yml
         dir: plates/pcb/top-alps/gerber
         board: plates/pcb/top-alps/corne-top-alps-plate.kicad_pcb
-        schema: plates/pcb/top-alps/corne-top-alps-plate.sch
 
     - name: Zip Gerber files
       run: |

--- a/.github/workflows/release-corne-light.yml
+++ b/.github/workflows/release-corne-light.yml
@@ -32,6 +32,20 @@ jobs:
         dir: plates/pcb/bottom/gerber
         board: plates/pcb/bottom/corne-bottom-plate.kicad_pcb
         schema: plates/pcb/bottom/corne-bottom-plate.sch
+    - name: Export top plate mini gerber
+      uses: nerdyscout/kicad-exports@v2.0
+      with:
+        config: .kiplot.yml
+        dir: plates/pcb/top-mini/gerber
+        board: plates/pcb/top-mini/corne-top-plate.kicad_pcb
+        schema: plates/pcb/top-mini/corne-top-plate.sch
+    - name: Export bottom plate mini gerber
+      uses: nerdyscout/kicad-exports@v2.0
+      with:
+        config: .kiplot.yml
+        dir: plates/pcb/bottom-mini/gerber
+        board: plates/pcb/bottom-mini/corne-bottom-plate.kicad_pcb
+        schema: plates/pcb/bottom-mini/corne-bottom-plate.sch
     - name: Export top-alps plate gerber
       uses: nerdyscout/kicad-exports@v2.0
       with:
@@ -44,8 +58,10 @@ jobs:
       run: |
           zip -r --junk-paths corne-light-gerber.zip corne-light/gerber
           zip -r --junk-paths plates-top-gerber.zip plates/pcb/top/gerber
+          zip -r --junk-paths plates-top-mini-gerber.zip plates/pcb/top-mini/gerber
           zip -r --junk-paths plates-top-alps-gerber.zip plates/pcb/top-alps/gerber
-          zip -r --junk-paths plates-bottom-gerber.zip plates/pcb/bottom/gerber
+          zip -r --junk-paths plates-bottom-gerber.zip plates/pcb/bottom-mini/gerber
+          zip -r --junk-paths plates-bottom-mini-gerber.zip plates/pcb/bottom/gerber
           zip -r --junk-paths plates.zip plates/common
           zip -r --junk-paths plates-alps.zip plates/alps
           zip -r --junk-paths plates-mini.zip plates/mini

--- a/.github/workflows/release-corne-light.yml
+++ b/.github/workflows/release-corne-light.yml
@@ -12,38 +12,38 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Export corne-light gerber
-      uses: INTI-CMNB/KiBot@v2
+      uses: INTI-CMNB/KiBot@v2_k6
       with:
         config: .kiplot.yml
         dir: corne-light/gerber
         board: corne-light/pcb/corne-light.kicad_pcb
         schema: corne-light/pcb/corne-light.kicad_sch
     - name: Export top plate gerber
-      uses: INTI-CMNB/KiBot@v2
+      uses: INTI-CMNB/KiBot@v2_k6
       with:
         config: .kiplot.yml
         dir: plates/pcb/top/gerber
         board: plates/pcb/top/corne-top-plate.kicad_pcb
     - name: Export bottom plate gerber
-      uses: INTI-CMNB/KiBot@v2
+      uses: INTI-CMNB/KiBot@v2_k6
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom/gerber
         board: plates/pcb/bottom/corne-bottom-plate.kicad_pcb
     - name: Export top plate mini gerber
-      uses: INTI-CMNB/KiBot@v2
+      uses: INTI-CMNB/KiBot@v2_k6
       with:
         config: .kiplot.yml
         dir: plates/pcb/top-mini/gerber
         board: plates/pcb/top-mini/corne-top-plate.kicad_pcb
     - name: Export bottom plate mini gerber
-      uses: INTI-CMNB/KiBot@v2
+      uses: INTI-CMNB/KiBot@v2_k6
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom-mini/gerber
         board: plates/pcb/bottom-mini/corne-bottom-plate.kicad_pcb
     - name: Export top-alps plate gerber
-      uses: INTI-CMNB/KiBot@v2
+      uses: INTI-CMNB/KiBot@v2_k6
       with:
         config: .kiplot.yml
         dir: plates/pcb/top-alps/gerber

--- a/.github/workflows/release-corne-light.yml
+++ b/.github/workflows/release-corne-light.yml
@@ -12,38 +12,38 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Export corne-light gerber
-      uses: nerdyscout/kicad-exports@v2.2
+      uses: nerdyscout/kicad-exports@v2.3
       with:
         config: .kiplot.yml
         dir: corne-light/gerber
         board: corne-light/pcb/corne-light.kicad_pcb
         schema: corne-light/pcb/corne-light.kicad_sch
     - name: Export top plate gerber
-      uses: nerdyscout/kicad-exports@v2.2
+      uses: nerdyscout/kicad-exports@v2.3
       with:
         config: .kiplot.yml
         dir: plates/pcb/top/gerber
         board: plates/pcb/top/corne-top-plate.kicad_pcb
     - name: Export bottom plate gerber
-      uses: nerdyscout/kicad-exports@v2.2
+      uses: nerdyscout/kicad-exports@v2.3
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom/gerber
         board: plates/pcb/bottom/corne-bottom-plate.kicad_pcb
     - name: Export top plate mini gerber
-      uses: nerdyscout/kicad-exports@v2.2
+      uses: nerdyscout/kicad-exports@v2.3
       with:
         config: .kiplot.yml
         dir: plates/pcb/top-mini/gerber
         board: plates/pcb/top-mini/corne-top-plate.kicad_pcb
     - name: Export bottom plate mini gerber
-      uses: nerdyscout/kicad-exports@v2.2
+      uses: nerdyscout/kicad-exports@v2.3
       with:
         config: .kiplot.yml
         dir: plates/pcb/bottom-mini/gerber
         board: plates/pcb/bottom-mini/corne-bottom-plate.kicad_pcb
     - name: Export top-alps plate gerber
-      uses: nerdyscout/kicad-exports@v2.2
+      uses: nerdyscout/kicad-exports@v2.3
       with:
         config: .kiplot.yml
         dir: plates/pcb/top-alps/gerber


### PR DESCRIPTION
Fixes #176 by building on top of #174. Lots of trial and error getting the GHA workflows passing with the newer versions of the KiCad files, but I got there in the end. Happy to rewrite the branch history, too, if that's important to you.

Here's the releases on my fork, which include the two new mini-plate Gerbers:
- https://github.com/jamesottaway/crkbd/releases/tag/corne-light-v0.1
- https://github.com/jamesottaway/crkbd/releases/tag/corne-classic-v0.1
- https://github.com/jamesottaway/crkbd/releases/tag/corne-cherry-v0.1
- https://github.com/jamesottaway/crkbd/releases/tag/corne-chocolate-v0.1